### PR TITLE
fix revalidate data

### DIFF
--- a/scripts/generate-token.ts
+++ b/scripts/generate-token.ts
@@ -6,7 +6,16 @@ async function generateToken() {
 
   try {
     // Invalidate any existing tokens for this email before creating a new one
-    await TokenService.invalidateTokensForEmail(email);
+    // Ignore errors if table doesn't exist or if there are no tokens to invalidate
+    try {
+      await TokenService.invalidateTokensForEmail(email);
+    } catch (invalidateError) {
+      // Log but don't fail - token generation can proceed
+      console.error(
+        "Warning: Failed to invalidate existing tokens:",
+        invalidateError
+      );
+    }
 
     const tokenUrl = await TokenService.issueOneTimeLoginToken(
       email,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix token revalidation to safely invalidate existing tokens and ensure consumedAt uses a proper Date. Token generation proceeds even if invalidation fails, improving reliability.

- **Bug Fixes**
  - TokenService: count tokens to invalidate, update them, and return an accurate count; wrap in try/catch with error logging.
  - Handle timestamp serialization so consumedAt is stored as a Date; added a test to simulate the production error and verify the fix.
  - generate-token script: log and ignore invalidation errors (e.g., missing table) so issuing a login token doesn’t fail.

<!-- End of auto-generated description by cubic. -->

