### PR TITLE
Implement spec test

### DIFF
--- a/.claude/skills/spec-explorer/SKILL.md
+++ b/.claude/skills/spec-explorer/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: spec-explorer
+description: Explore a website using AI-powered browser automation and generate behavior specifications in Epic format. This skill should be used when users want to document an existing website flow, discover UI interactions, or generate test specifications from a running application. Triggers on "explore", "discover", or "document" a website.
+---
+
+# Spec Explorer
+
+## Overview
+
+This skill explores websites using Stagehand's AI-powered browser automation and generates behavior specifications in Epic format. The output is compatible with the spec-test library for automated testing.
+
+## Usage
+
+```bash
+bun .claude/skills/spec-explorer/scripts/explore.ts <url> "<flow-description>"
+```
+
+### Examples
+
+```bash
+# Explore login flow
+bun .claude/skills/spec-explorer/scripts/explore.ts https://myapp.com/login "login with email"
+
+# Save to file
+OUTPUT_FILE=docs/specs/login.md bun .claude/skills/spec-explorer/scripts/explore.ts https://myapp.com/login "login flow"
+
+# Run headless
+HEADLESS=true bun .claude/skills/spec-explorer/scripts/explore.ts https://myapp.com "signup"
+```
+
+### Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `OPENAI_API_KEY` | Yes | For Stagehand AI |
+| `OUTPUT_FILE` | No | Save spec to file (default: stdout) |
+| `MAX_STEPS` | No | Max exploration steps (default: 10) |
+| `HEADLESS` | No | Headless browser (default: false) |
+
+## How It Works
+
+1. Navigate to URL
+2. Use `stagehand.observe()` to discover interactive elements
+3. Use `stagehand.act()` to navigate through the flow
+4. Record actions as Act steps, URL changes as Check steps
+5. Output Epic format spec
+
+## Output Format
+
+```markdown
+# [Behavior Name]
+
+[Description]
+
+## Examples
+
+### [Scenario] - Happy Path
+
+#### Steps
+* Act: User clicks Login button
+* Act: User enters "test@example.com" in email field
+* Check: URL contains /dashboard
+```
+
+## Integration with spec-test
+
+```bash
+# 1. Generate spec
+OUTPUT_FILE=docs/specs/login.md bun .claude/skills/spec-explorer/scripts/explore.ts https://myapp.com/login "login"
+
+# 2. Run as tests
+bun lib/spec-test/tests/run-spec.ts docs/specs/login.md
+```
+
+## Reference
+
+- Epic spec format: `lib/spec-test/README.md`
+- Stagehand: `@browserbasehq/stagehand`

--- a/.claude/skills/spec-explorer/scripts/explore.ts
+++ b/.claude/skills/spec-explorer/scripts/explore.ts
@@ -1,0 +1,183 @@
+#!/usr/bin/env bun
+/**
+ * spec-explorer: Explore a website and generate behavior specifications
+ *
+ * Usage:
+ *   bun .claude/skills/spec-explorer/scripts/explore.ts <url> "<flow-description>"
+ *
+ * Environment Variables:
+ *   OPENAI_API_KEY  - Required for Stagehand
+ *   OUTPUT_FILE     - Save spec to file (default: stdout)
+ *   MAX_STEPS       - Max steps (default: 10)
+ *   HEADLESS        - Headless browser (default: false)
+ */
+
+import { Stagehand } from "@browserbasehq/stagehand";
+import { writeFileSync } from "fs";
+
+const URL_ARG = process.argv[2];
+const FLOW_DESCRIPTION = process.argv[3];
+const OUTPUT_FILE = process.env.OUTPUT_FILE;
+const MAX_STEPS = parseInt(process.env.MAX_STEPS ?? "10", 10);
+const HEADLESS = process.env.HEADLESS === "true";
+
+interface RecordedStep {
+  type: "act" | "check";
+  instruction: string;
+}
+
+function printUsage() {
+  console.log(`
+spec-explorer: Explore a website and generate behavior specs
+
+Usage:
+  bun .claude/skills/spec-explorer/scripts/explore.ts <url> "<flow-description>"
+
+Examples:
+  bun .claude/skills/spec-explorer/scripts/explore.ts https://myapp.com/login "login flow"
+  OUTPUT_FILE=docs/specs/login.md bun .claude/skills/spec-explorer/scripts/explore.ts https://myapp.com "signup"
+`);
+}
+
+function toBehaviorName(desc: string): string {
+  return desc
+    .split(" ")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+    .join(" ");
+}
+
+function generateSpec(name: string, desc: string, steps: RecordedStep[], url: string): string {
+  const lines = [
+    `# ${name}`,
+    "",
+    `${desc}`,
+    "",
+    "## Examples",
+    "",
+    `### ${name} - Happy Path`,
+    "",
+    "#### Steps",
+    ...steps.map((s) => `* ${s.type === "act" ? "Act" : "Check"}: ${s.instruction}`),
+    "",
+  ];
+  return lines.join("\n");
+}
+
+async function explore(url: string, flowDescription: string) {
+  console.error("Starting browser...");
+
+  const stagehand = new Stagehand({
+    env: "LOCAL",
+    localBrowserLaunchOptions: { headless: HEADLESS },
+  });
+
+  await stagehand.init();
+  const page = stagehand.context.activePage();
+  if (!page) {
+    throw new Error("Failed to get active page from Stagehand");
+  }
+
+  const steps: RecordedStep[] = [];
+  let currentUrl = url;
+
+  try {
+    // Navigate to URL
+    console.error(`Navigating to ${url}...`);
+    await page.goto(url);
+    currentUrl = page.url();
+
+    const urlPath = new URL(url).pathname || "/";
+    steps.push({ type: "act", instruction: `User navigates to ${urlPath}` });
+
+    // Explore the flow
+    for (let i = 0; i < MAX_STEPS; i++) {
+      const context = steps.map((s) => s.instruction).join(", ");
+      const prompt = i === 0
+        ? `To ${flowDescription}, what is the first action to take?`
+        : `Continue ${flowDescription}. Done: ${context}. What's next?`;
+
+      console.error(`Step ${i + 1}: Observing...`);
+      const observations = await stagehand.observe(prompt);
+
+      if (!observations || observations.length === 0) {
+        console.error("No more actions found.");
+        break;
+      }
+
+      const observation = observations[0];
+      const description = observation.description || "Unknown action";
+
+      console.error(`  -> ${description}`);
+
+      try {
+        await stagehand.act(observation);
+        steps.push({ type: "act", instruction: `User ${description}` });
+
+        const newUrl = page.url();
+        if (newUrl !== currentUrl) {
+          const newPath = new URL(newUrl).pathname;
+          steps.push({ type: "check", instruction: `URL contains ${newPath}` });
+          currentUrl = newUrl;
+        }
+
+        await new Promise((r) => setTimeout(r, 500));
+      } catch (err) {
+        console.error(`  Action failed: ${err}`);
+        break;
+      }
+    }
+
+    // Final observation for semantic check
+    const finalObs = await stagehand.observe("What is the main visible content or success indicator?");
+    if (finalObs && finalObs.length > 0) {
+      const indicator = finalObs[0].description || "";
+      if (indicator && !indicator.toLowerCase().includes("click")) {
+        steps.push({ type: "check", instruction: `${indicator} is displayed` });
+      }
+    }
+
+    return {
+      name: toBehaviorName(flowDescription),
+      description: `Exploration of ${flowDescription} starting from ${url}.`,
+      steps,
+      finalUrl: page.url(),
+    };
+  } finally {
+    await stagehand.close();
+  }
+}
+
+async function main() {
+  if (!URL_ARG || !FLOW_DESCRIPTION) {
+    printUsage();
+    process.exit(1);
+  }
+
+  if (!process.env.OPENAI_API_KEY) {
+    console.error("Error: OPENAI_API_KEY required");
+    process.exit(1);
+  }
+
+  console.error("=".repeat(50));
+  console.error("spec-explorer");
+  console.error("=".repeat(50));
+  console.error(`URL: ${URL_ARG}`);
+  console.error(`Flow: ${FLOW_DESCRIPTION}`);
+  console.error("");
+
+  const result = await explore(URL_ARG, FLOW_DESCRIPTION);
+  const spec = generateSpec(result.name, result.description, result.steps, URL_ARG);
+
+  if (OUTPUT_FILE) {
+    writeFileSync(OUTPUT_FILE, spec);
+    console.error(`\nSpec saved to: ${OUTPUT_FILE}`);
+  } else {
+    console.log(spec);
+  }
+
+  console.error("\n" + "=".repeat(50));
+  console.error(`Done! ${result.steps.length} steps recorded.`);
+  console.error("=".repeat(50));
+}
+
+main();

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "agents",
       "dependencies": {
         "@ai-sdk/openai": "^2.0.57",
+        "@browserbasehq/stagehand": "^3.0.7",
         "@hookform/resolvers": "^5.2.2",
         "@libsql/client": "^0.15.15",
         "@radix-ui/react-accordion": "^1.2.12",
@@ -46,14 +47,13 @@
         "lucide-react": "^0.546.0",
         "next": "16.0.10",
         "next-themes": "^0.4.6",
-        "pino": "^10.1.0",
         "react": "^19.2.3",
         "react-day-picker": "^9.11.1",
         "react-dom": "^19.2.3",
         "react-hook-form": "^7.65.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",
-        "zod": "^4.1.12",
+        "zod": "^4.3.5",
       },
       "devDependencies": {
         "@playwright/test": "^1.56.1",
@@ -83,17 +83,43 @@
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 
+    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@2.0.57", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@ai-sdk/provider-utils": "3.0.20" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-DREpYqW2pylgaj69gZ+K8u92bo9DaMgFdictYnY+IwYeY3bawQ4zI7l/o1VkDsBDljAx8iYz5lPURwVZNu+Xpg=="],
+
+    "@ai-sdk/azure": ["@ai-sdk/azure@2.0.91", "", { "dependencies": { "@ai-sdk/openai": "2.0.89", "@ai-sdk/provider": "2.0.1", "@ai-sdk/provider-utils": "3.0.20" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-9tznVSs6LGQNKKxb8pKd7CkBV9yk+a/ENpFicHCj2CmBUKefxzwJ9JbUqrlK3VF6dGZw3LXq0dWxt7/Yekaj1w=="],
+
+    "@ai-sdk/cerebras": ["@ai-sdk/cerebras@1.0.34", "", { "dependencies": { "@ai-sdk/openai-compatible": "1.0.30", "@ai-sdk/provider": "2.0.1", "@ai-sdk/provider-utils": "3.0.20" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-XOK0dJsAGoPYi/lfR4KFBi8xhvJ46oCpAxUD6FmJAuJ4eh0qlj5zDt+myvzM8gvN7S6K7zHD+mdWlOPKGQT8Vg=="],
+
+    "@ai-sdk/deepseek": ["@ai-sdk/deepseek@1.0.33", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@ai-sdk/provider-utils": "3.0.20" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-NiKjvqXI/96e/7SjZGgQH141PBqggsF7fNbjGTv4RgVWayMXp9mj0Ou2NjAUGwwxJwj/qseY0gXiDCYaHWFBkw=="],
+
     "@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.3", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.14", "@vercel/oidc": "3.0.3" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-/vCoMKtod+A74/BbkWsaAflWKz1ovhX5lmJpIaXQXtd6gyexZncjotBTbFM8rVJT9LKJ/Kx7iVVo3vh+KT+IJg=="],
 
+    "@ai-sdk/google": ["@ai-sdk/google@2.0.52", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@ai-sdk/provider-utils": "3.0.20" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-2XUnGi3f7TV4ujoAhA+Fg3idUoG/+Y2xjCRg70a1/m0DH1KSQqYaCboJ1C19y6ZHGdf5KNT20eJdswP6TvrY2g=="],
+
+    "@ai-sdk/google-vertex": ["@ai-sdk/google-vertex@3.0.97", "", { "dependencies": { "@ai-sdk/anthropic": "2.0.57", "@ai-sdk/google": "2.0.52", "@ai-sdk/provider": "2.0.1", "@ai-sdk/provider-utils": "3.0.20", "google-auth-library": "^10.5.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-s4tI7Z15i6FlbtCvS4SBRal8wRfkOXJzKxlS6cU4mJW/QfUfoVy4b22836NVNJwDvkG/HkDSfzwm/X8mn46MhA=="],
+
+    "@ai-sdk/groq": ["@ai-sdk/groq@2.0.34", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@ai-sdk/provider-utils": "3.0.20" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-wfCYkVgmVjxNA32T57KbLabVnv9aFUflJ4urJ7eWgTwbnmGQHElCTu+rJ3ydxkXSqxOkXPwMOttDm7XNrvPjmg=="],
+
+    "@ai-sdk/mistral": ["@ai-sdk/mistral@2.0.27", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@ai-sdk/provider-utils": "3.0.20" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-gaptHgaXjMw3+eA0Q4FABcsj5nQNP6EpFaGUR+Pj5WJy7Kn6mApl975/x57224MfeJIShNpt8wFKK3tvh5ewKg=="],
+
     "@ai-sdk/openai": ["@ai-sdk/openai@2.0.57", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.14" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ad2e4Ah9KdLnchMcWFv2FfU1JCwm50b3+UZq2VhkO8qLYEh2kh/aVQomZyAsIbx5ft5nOv2KmDwZrefXkeKttQ=="],
+
+    "@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@1.0.30", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@ai-sdk/provider-utils": "3.0.20" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-thubwhRtv9uicAxSWwNpinM7hiL/0CkhL/ymPaHuKvI494J7HIzn8KQZQ2ymRz284WTIZnI7VMyyejxW4RMM6w=="],
+
+    "@ai-sdk/perplexity": ["@ai-sdk/perplexity@2.0.23", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@ai-sdk/provider-utils": "3.0.20" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-aiaRvnc6mhQZKhTTSXPCjPH8Iqr5D/PfCN1hgVP/3RGTBbJtsd9HemIBSABeSdAKbsMH/PwJxgnqH75HEamcBA=="],
 
     "@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
 
     "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.14", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CYRU6L7IlR7KslSBVxvlqlybQvXJln/PI57O8swhOaDIURZbjRP2AY3igKgUsrmWqqnFFUHP+AwTN8xqJAknnA=="],
 
+    "@ai-sdk/togetherai": ["@ai-sdk/togetherai@1.0.31", "", { "dependencies": { "@ai-sdk/openai-compatible": "1.0.30", "@ai-sdk/provider": "2.0.1", "@ai-sdk/provider-utils": "3.0.20" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-RlYubjStoZQxna4Ng91Vvo8YskvL7lW9zj68IwZfCnaDBSAp1u6Nhc5BR4ZtKnY6PA3XEtu4bATIQl7yiiQ+Lw=="],
+
+    "@ai-sdk/xai": ["@ai-sdk/xai@2.0.44", "", { "dependencies": { "@ai-sdk/openai-compatible": "1.0.30", "@ai-sdk/provider": "2.0.1", "@ai-sdk/provider-utils": "3.0.20" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-tqSkfQpsdtqm2rMZWA40VuDUmvIJdqjfe5TY6NytPKRqiCaXeN1U0yGZV6vnFYjZHAB1n/SPte8Y/8wxnGASHA=="],
+
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@antfu/ni": ["@antfu/ni@25.0.0", "", { "dependencies": { "ansis": "^4.0.0", "fzf": "^0.5.2", "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" }, "bin": { "na": "bin/na.mjs", "ni": "bin/ni.mjs", "nr": "bin/nr.mjs", "nci": "bin/nci.mjs", "nlx": "bin/nlx.mjs", "nun": "bin/nun.mjs", "nup": "bin/nup.mjs" } }, "sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA=="],
+
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.39.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg=="],
 
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@4.0.5", "", { "dependencies": { "@csstools/css-calc": "^2.1.4", "@csstools/css-color-parser": "^3.1.0", "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4", "lru-cache": "^11.2.1" } }, "sha512-lMrXidNhPGsDjytDy11Vwlb6OIGrT3CmLg3VWNFyWkLWtijKl7xjvForlh8vuj0SHGjgl4qZEQzUmYTeQA2JFQ=="],
 
@@ -168,6 +194,12 @@
     "@better-auth/utils": ["@better-auth/utils@0.3.0", "", {}, "sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw=="],
 
     "@better-fetch/fetch": ["@better-fetch/fetch@1.1.18", "", {}, "sha512-rEFOE1MYIsBmoMJtQbl32PGHHXuG2hDxvEd7rUHE0vCBoFQVSDqaVs9hkZEtHCxRoY+CljXKFCOuJ8uxqw1LcA=="],
+
+    "@browserbasehq/sdk": ["@browserbasehq/sdk@2.6.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-83iXP5D7xMm8Wyn66TUaUrgoByCmAJuoMoZQI3sGg3JAiMlTfnCIMqyVBoNSaItaPIkaCnrsj6LiusmXV2X9YA=="],
+
+    "@browserbasehq/stagehand": ["@browserbasehq/stagehand@3.0.7", "", { "dependencies": { "@ai-sdk/provider": "^2.0.0", "@anthropic-ai/sdk": "0.39.0", "@browserbasehq/sdk": "^2.4.0", "@google/genai": "^1.22.0", "@langchain/openai": "^0.4.4", "@modelcontextprotocol/sdk": "^1.17.2", "ai": "^5.0.0", "devtools-protocol": "^0.0.1464554", "fetch-cookie": "^3.1.0", "openai": "^4.87.1", "pino": "^9.6.0", "pino-pretty": "^13.0.0", "uuid": "^11.1.0", "ws": "^8.18.0", "zod-to-json-schema": "^3.25.0" }, "optionalDependencies": { "@ai-sdk/anthropic": "^2.0.34", "@ai-sdk/azure": "^2.0.54", "@ai-sdk/cerebras": "^1.0.25", "@ai-sdk/deepseek": "^1.0.23", "@ai-sdk/google": "^2.0.23", "@ai-sdk/google-vertex": "^3.0.70", "@ai-sdk/groq": "^2.0.24", "@ai-sdk/mistral": "^2.0.19", "@ai-sdk/openai": "^2.0.53", "@ai-sdk/perplexity": "^2.0.13", "@ai-sdk/togetherai": "^1.0.23", "@ai-sdk/xai": "^2.0.26", "@langchain/core": "^0.3.40", "bufferutil": "^4.0.9", "chrome-launcher": "^1.2.0", "ollama-ai-provider-v2": "^1.5.0", "patchright-core": "^1.55.2", "playwright": "^1.52.0", "playwright-core": "^1.54.1", "puppeteer-core": "^22.8.0" }, "peerDependencies": { "deepmerge": "^4.3.1", "dotenv": "^16.4.5", "zod": "^3.25.76 || ^4.2.0" } }, "sha512-8VEDKFDksYl1407RYtDRWxmE58W5r6CtMsz3WX1w8wypxt8ZhS1ywYt95YeF5h5R/TborZAszocuYkmeKJHm9Q=="],
+
+    "@cfworker/json-schema": ["@cfworker/json-schema@4.1.1", "", {}, "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
 
@@ -277,6 +309,8 @@
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
 
+    "@google/genai": ["@google/genai@1.35.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.24.0" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-ZC1d0PSM5eS73BpbVIgL3ZsmXeMKLVJurxzww1Z9axy3B2eUB3ioEytbQt4Qu0Od6qPluKrTDew9pSi9kEuPaw=="],
+
     "@hexagon/base64": ["@hexagon/base64@1.1.28", "", {}, "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw=="],
 
     "@hookform/resolvers": ["@hookform/resolvers@5.2.2", "", { "dependencies": { "@standard-schema/utils": "^0.3.0" }, "peerDependencies": { "react-hook-form": "^7.55.0" } }, "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA=="],
@@ -360,6 +394,10 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@langchain/core": ["@langchain/core@0.3.80", "", { "dependencies": { "@cfworker/json-schema": "^4.0.2", "ansi-styles": "^5.0.0", "camelcase": "6", "decamelize": "1.2.0", "js-tiktoken": "^1.0.12", "langsmith": "^0.3.67", "mustache": "^4.2.0", "p-queue": "^6.6.2", "p-retry": "4", "uuid": "^10.0.0", "zod": "^3.25.32", "zod-to-json-schema": "^3.22.3" } }, "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA=="],
+
+    "@langchain/openai": ["@langchain/openai@0.4.9", "", { "dependencies": { "js-tiktoken": "^1.0.12", "openai": "^4.87.3", "zod": "^3.22.4", "zod-to-json-schema": "^3.22.3" }, "peerDependencies": { "@langchain/core": ">=0.3.39 <0.4.0" } }, "sha512-NAsaionRHNdqaMjVLPkFCyjUDze+OqRHghA1Cn4fPoAafz+FXcl9c7LlEl9Xo0FH6/8yiCl7Rw2t780C/SBVxQ=="],
 
     "@levischuck/tiny-cbor": ["@levischuck/tiny-cbor@0.2.11", "", {}, "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow=="],
 
@@ -467,7 +505,11 @@
 
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
 
+    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
     "@playwright/test": ["@playwright/test@1.56.1", "", { "dependencies": { "playwright": "1.56.1" }, "bin": { "playwright": "cli.js" } }, "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg=="],
+
+    "@puppeteer/browsers": ["@puppeteer/browsers@2.3.0", "", { "dependencies": { "debug": "^4.3.5", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.4.0", "semver": "^7.6.3", "tar-fs": "^3.0.6", "unbzip2-stream": "^1.4.3", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
@@ -673,6 +715,8 @@
 
     "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
 
+    "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
+
     "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
@@ -699,13 +743,21 @@
 
     "@types/node": ["@types/node@20.19.24", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-FE5u0ezmi6y9OZEzlJfg37mqqf6ZDSF2V/NLjUyGrR9uTZ7Sb9F7bLNZ03S4XVUNRWGA7Ck4c1kK+YnuWjl+DA=="],
 
+    "@types/node-fetch": ["@types/node-fetch@2.6.13", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.4" } }, "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw=="],
+
     "@types/react": ["@types/react@19.2.2", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.2", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw=="],
 
+    "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
+
     "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
 
+    "@types/uuid": ["@types/uuid@10.0.0", "", {}, "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="],
+
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.46.2", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.46.2", "@typescript-eslint/type-utils": "8.46.2", "@typescript-eslint/utils": "8.46.2", "@typescript-eslint/visitor-keys": "8.46.2", "graphemer": "^1.4.0", "ignore": "^7.0.0", "natural-compare": "^1.4.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.46.2", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-ZGBMToy857/NIPaaCucIUQgqueOiq7HeAKkhlvqVV4lm089zUFW6ikRySx2v+cAhKeUCPuWVHeimyk6Dw1iY3w=="],
 
@@ -783,6 +835,8 @@
 
     "@vitest/utils": ["@vitest/utils@4.0.5", "", { "dependencies": { "@vitest/pretty-format": "4.0.5", "tinyrainbow": "^3.0.3" } }, "sha512-V5RndUgCB5/AfNvK9zxGCrRs99IrPYtMTIdUzJMMFs9nrmE5JXExIEfjVtUteyTRiLfCm+dCRMHf/Uu7Mm8/dg=="],
 
+    "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
+
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
@@ -790,6 +844,8 @@
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
 
     "ai": ["ai@5.0.82", "", { "dependencies": { "@ai-sdk/gateway": "2.0.3", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.14", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-wmZZfsU40qB77umrcj3YzMSk6cUP5gxLXZDPfiSQLBLegTVXPUdSJC603tR7JB5JkhBDzN5VLaliuRKQGKpUXg=="],
 
@@ -833,6 +889,8 @@
 
     "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
 
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
 
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
@@ -841,15 +899,35 @@
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
+    "b4a": ["b4a@1.7.3", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q=="],
+
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
+    "bare-events": ["bare-events@2.8.2", "", { "peerDependencies": { "bare-abort-controller": "*" }, "optionalPeers": ["bare-abort-controller"] }, "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ=="],
+
+    "bare-fs": ["bare-fs@4.5.2", "", { "dependencies": { "bare-events": "^2.5.4", "bare-path": "^3.0.0", "bare-stream": "^2.6.4", "bare-url": "^2.2.2", "fast-fifo": "^1.3.2" }, "peerDependencies": { "bare-buffer": "*" }, "optionalPeers": ["bare-buffer"] }, "sha512-veTnRzkb6aPHOvSKIOy60KzURfBdUflr5VReI+NSaPL6xf+XLdONQgZgpYvUuZLVQ8dCqxpBAudaOM1+KpAUxw=="],
+
+    "bare-os": ["bare-os@3.6.2", "", {}, "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A=="],
+
+    "bare-path": ["bare-path@3.0.0", "", { "dependencies": { "bare-os": "^3.0.1" } }, "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw=="],
+
+    "bare-stream": ["bare-stream@2.7.0", "", { "dependencies": { "streamx": "^2.21.0" }, "peerDependencies": { "bare-buffer": "*", "bare-events": "*" }, "optionalPeers": ["bare-buffer", "bare-events"] }, "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A=="],
+
+    "bare-url": ["bare-url@2.3.2", "", { "dependencies": { "bare-path": "^3.0.0" } }, "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
     "baseline-browser-mapping": ["baseline-browser-mapping@2.8.21", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-JU0h5APyQNsHOlAM7HnQnPToSDQoEBZqzu/YBlqDnEeymPnZDREeXJA3KBMQee+dKteAxZ2AtvQEvVYdZf241Q=="],
+
+    "basic-ftp": ["basic-ftp@5.1.0", "", {}, "sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw=="],
 
     "better-auth": ["better-auth@1.3.34", "", { "dependencies": { "@better-auth/core": "1.3.34", "@better-auth/telemetry": "1.3.34", "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.18", "@noble/ciphers": "^2.0.0", "@noble/hashes": "^2.0.0", "@simplewebauthn/browser": "^13.1.2", "@simplewebauthn/server": "^13.1.2", "better-call": "1.0.19", "defu": "^6.1.4", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1", "zod": "^4.1.5" } }, "sha512-LWA52SlvnUBJRbN8VLSTLILPomZY3zZAiLxVJCeSQ5uVmaIKkMBhERitkfJcXB9RJcfl4uP+3EqKkb6hX1/uiw=="],
 
     "better-call": ["better-call@1.0.19", "", { "dependencies": { "@better-auth/utils": "^0.3.0", "@better-fetch/fetch": "^1.1.4", "rou3": "^0.5.1", "set-cookie-parser": "^2.7.1", "uncrypto": "^0.1.3" } }, "sha512-sI3GcA1SCVa3H+CDHl8W8qzhlrckwXOTKhqq3OOPXjgn5aTOMIqGY34zLY/pHA6tRRMjTUC3lz5Mi7EbDA24Kw=="],
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
+
+    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
     "body-parser": ["body-parser@2.2.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.0", "http-errors": "^2.0.0", "iconv-lite": "^0.6.3", "on-finished": "^2.4.1", "qs": "^6.14.0", "raw-body": "^3.0.0", "type-is": "^2.0.0" } }, "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg=="],
 
@@ -859,7 +937,15 @@
 
     "browserslist": ["browserslist@4.27.0", "", { "dependencies": { "baseline-browser-mapping": "^2.8.19", "caniuse-lite": "^1.0.30001751", "electron-to-chromium": "^1.5.238", "node-releases": "^2.0.26", "update-browserslist-db": "^1.1.4" }, "bin": { "browserslist": "cli.js" } }, "sha512-AXVQwdhot1eqLihwasPElhX2tAZiBjWdJ9i/Zcj2S6QYIjkx62OKSfnobkriB81C3l4w0rVy3Nt4jaTBltYEpw=="],
 
+    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+
+    "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
+
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bufferutil": ["bufferutil@4.1.0", "", { "dependencies": { "node-gyp-build": "^4.3.0" } }, "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw=="],
 
     "bun-types": ["bun-types@1.3.1", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-NMrcy7smratanWJ2mMXdpatalovtxVggkj11bScuWuiOoXTiKIu2eVS1/7qbyI/4yHedtsn175n4Sm4JcdHLXw=="],
 
@@ -873,11 +959,17 @@
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
+    "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
+
     "caniuse-lite": ["caniuse-lite@1.0.30001751", "", {}, "sha512-A0QJhug0Ly64Ii3eIqHu5X51ebln3k4yTUkY1j8drqpWHVreg/VLijN48cZ1bYPiqOQuqpkIKnzr/Ul8V+p6Cw=="],
 
     "chai": ["chai@6.2.0", "", {}, "sha512-aUTnJc/JipRzJrNADXVvpVqi6CO0dn3nx4EVPxijri+fj3LUUDyZQOgVeW54Ob3Y1Xh9Iz8f+CgaCl8v0mn9bA=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "chrome-launcher": ["chrome-launcher@1.2.1", "", { "dependencies": { "@types/node": "*", "escape-string-regexp": "^4.0.0", "is-wsl": "^2.2.0", "lighthouse-logger": "^2.0.1" }, "bin": { "print-chrome-path": "bin/print-chrome-path.cjs" } }, "sha512-qmFR5PLMzHyuNJHwOloHPAHhbaNglkfeV/xDtt5b7xiFFyU1I+AZZX0PYseMuhenJSSirgxELYIbswcoc+5H4A=="],
+
+    "chromium-bidi": ["chromium-bidi@0.6.3", "", { "dependencies": { "mitt": "3.0.1", "urlpattern-polyfill": "10.0.0", "zod": "3.23.8" }, "peerDependencies": { "devtools-protocol": "*" } }, "sha512-qXlsCmpCZJAnoTYI83Iu6EdYQpMYdVkCfq08KDh2pmlVqK5t5IA9mGs4/LwCwp4fqisSOMXZxP3HIh8w8aRn0A=="],
 
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
@@ -901,9 +993,15 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
+    "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
+
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
     "commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "console-table-printer": ["console-table-printer@2.15.0", "", { "dependencies": { "simple-wcswidth": "^1.1.2" } }, "sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw=="],
 
     "content-disposition": ["content-disposition@1.0.0", "", { "dependencies": { "safe-buffer": "5.2.1" } }, "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg=="],
 
@@ -945,7 +1043,11 @@
 
     "date-fns-jalali": ["date-fns-jalali@4.1.0-0", "", {}, "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg=="],
 
+    "dateformat": ["dateformat@4.6.3", "", {}, "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decamelize": ["decamelize@1.2.0", "", {}, "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="],
 
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
@@ -961,11 +1063,17 @@
 
     "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
 
+    "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
     "detect-libc": ["detect-libc@2.0.2", "", {}, "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
+
+    "devtools-protocol": ["devtools-protocol@0.0.1464554", "", {}, "sha512-CAoP3lYfwAGQTaAXYvA6JZR0fjGUb7qec1qf4mToyoH2TZgUFeIqYcjh6f9jNuhHfuZiEdH+PONHYrLhRQX6aw=="],
 
     "diff": ["diff@8.0.2", "", {}, "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg=="],
 
@@ -983,6 +1091,8 @@
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
+
     "eciesjs": ["eciesjs@0.4.16", "", { "dependencies": { "@ecies/ciphers": "^0.2.4", "@noble/ciphers": "^1.3.0", "@noble/curves": "^1.9.7", "@noble/hashes": "^1.8.0" } }, "sha512-dS5cbA9rA2VR4Ybuvhg6jvdmp46ubLn3E+px8cG/35aEDNclrqoCjg6mt0HYZ/M+OoESS3jSkCrqk1kWAEhWAw=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
@@ -992,6 +1102,8 @@
     "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.18.3", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww=="],
 
@@ -1028,6 +1140,8 @@
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "escodegen": ["escodegen@2.1.0", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^5.2.0", "esutils": "^2.0.2" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w=="],
 
     "eslint": ["eslint@9.38.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.1", "@eslint/config-helpers": "^0.4.1", "@eslint/core": "^0.16.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.38.0", "@eslint/plugin-kit": "^0.4.0", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw=="],
 
@@ -1067,6 +1181,12 @@
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
+    "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
+
+    "eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
+
+    "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
+
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
@@ -1079,7 +1199,15 @@
 
     "express-rate-limit": ["express-rate-limit@7.5.1", "", { "peerDependencies": { "express": ">= 4.11" } }, "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw=="],
 
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
+
+    "fast-copy": ["fast-copy@4.0.2", "", {}, "sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
@@ -1087,11 +1215,17 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
+    "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
+
     "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
+
+    "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
+
+    "fetch-cookie": ["fetch-cookie@3.2.0", "", { "dependencies": { "set-cookie-parser": "^2.4.8", "tough-cookie": "^6.0.0" } }, "sha512-n61pQIxP25C6DRhcJxn7BDzgHP/+S56Urowb5WFxtcRMpU6drqXD90xjyAsVQYsNSNNVbaCcYY1DuHsdkZLuiA=="],
 
     "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
 
@@ -1110,6 +1244,12 @@
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
+    "form-data-encoder": ["form-data-encoder@1.7.2", "", {}, "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="],
+
+    "formdata-node": ["formdata-node@4.4.1", "", { "dependencies": { "node-domexception": "1.0.0", "web-streams-polyfill": "4.0.0-beta.3" } }, "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ=="],
 
     "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
 
@@ -1130,6 +1270,10 @@
     "fuzzysort": ["fuzzysort@3.1.0", "", {}, "sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ=="],
 
     "fzf": ["fzf@0.5.2", "", {}, "sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q=="],
+
+    "gaxios": ["gaxios@7.1.3", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2", "rimraf": "^5.0.1" } }, "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ=="],
+
+    "gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
 
     "generator-function": ["generator-function@2.0.1", "", {}, "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="],
 
@@ -1153,6 +1297,8 @@
 
     "get-tsconfig": ["get-tsconfig@4.13.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ=="],
 
+    "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
+
     "glob": ["glob@11.0.3", "", { "dependencies": { "foreground-child": "^3.3.1", "jackspeak": "^4.1.1", "minimatch": "^10.0.3", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
@@ -1163,6 +1309,10 @@
 
     "globrex": ["globrex@0.1.2", "", {}, "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="],
 
+    "google-auth-library": ["google-auth-library@10.5.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.0.0", "gcp-metadata": "^8.0.0", "google-logging-utils": "^1.0.0", "gtoken": "^8.0.0", "jws": "^4.0.0" } }, "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w=="],
+
+    "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
+
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
@@ -1170,6 +1320,8 @@
     "graphemer": ["graphemer@1.4.0", "", {}, "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="],
 
     "graphql": ["graphql@16.11.0", "", {}, "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw=="],
+
+    "gtoken": ["gtoken@8.0.0", "", { "dependencies": { "gaxios": "^7.0.0", "jws": "^4.0.0" } }, "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
@@ -1187,6 +1339,8 @@
 
     "headers-polyfill": ["headers-polyfill@4.0.3", "", {}, "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ=="],
 
+    "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
+
     "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
 
     "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
@@ -1201,7 +1355,11 @@
 
     "human-signals": ["human-signals@8.0.1", "", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
 
+    "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
+
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -1214,6 +1372,8 @@
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
+
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
@@ -1236,6 +1396,8 @@
     "is-data-view": ["is-data-view@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "get-intrinsic": "^1.2.6", "is-typed-array": "^1.1.13" } }, "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw=="],
 
     "is-date-object": ["is-date-object@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg=="],
+
+    "is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
@@ -1291,6 +1453,8 @@
 
     "is-weakset": ["is-weakset@2.0.4", "", { "dependencies": { "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ=="],
 
+    "is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
+
     "isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
@@ -1305,7 +1469,11 @@
 
     "jotai": ["jotai@2.15.1", "", { "peerDependencies": { "@babel/core": ">=7.0.0", "@babel/template": ">=7.0.0", "@types/react": ">=17.0.0", "react": ">=17.0.0" }, "optionalPeers": ["@babel/core", "@babel/template", "@types/react", "react"] }, "sha512-yHT1HAZ3ba2Q8wgaUQ+xfBzEtcS8ie687I8XVCBinfg4bNniyqLIN+utPXWKQE93LMF5fPbQSVRZqgpcN5yd6Q=="],
 
+    "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
+
     "js-base64": ["js-base64@3.7.8", "", {}, "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow=="],
+
+    "js-tiktoken": ["js-tiktoken@1.0.21", "", { "dependencies": { "base64-js": "^1.5.1" } }, "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -1314,6 +1482,8 @@
     "jsdom": ["jsdom@27.0.1", "", { "dependencies": { "@asamuzakjp/dom-selector": "^6.7.2", "cssstyle": "^5.3.1", "data-urls": "^6.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^4.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.6", "is-potential-custom-element-name": "^1.0.1", "parse5": "^8.0.0", "rrweb-cssom": "^0.8.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.0", "whatwg-encoding": "^3.1.1", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^15.1.0", "ws": "^8.18.3", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-SNSQteBL1IlV2zqhwwolaG9CwhIhTvVHWg3kTss/cLE7H/X4644mtPQqYvCfsSrGQWt9hSZcgOXX8bOZaMN+kA=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
@@ -1331,11 +1501,17 @@
 
     "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "^3.1.6", "array.prototype.flat": "^1.3.1", "object.assign": "^4.1.4", "object.values": "^1.1.6" } }, "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ=="],
 
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
+
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
     "kysely": ["kysely@0.28.8", "", {}, "sha512-QUOgl5ZrS9IRuhq5FvOKFSsD/3+IA6MLE81/bOOTRA/YQpKDza2sFdN5g6JCB9BOpqMJDGefLCQ9F12hRS13TA=="],
+
+    "langsmith": ["langsmith@0.3.87", "", { "dependencies": { "@types/uuid": "^10.0.0", "chalk": "^4.1.2", "console-table-printer": "^2.12.1", "p-queue": "^6.6.2", "semver": "^7.6.3", "uuid": "^10.0.0" }, "peerDependencies": { "@opentelemetry/api": "*", "@opentelemetry/exporter-trace-otlp-proto": "*", "@opentelemetry/sdk-trace-base": "*", "openai": "*" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/exporter-trace-otlp-proto", "@opentelemetry/sdk-trace-base", "openai"] }, "sha512-XXR1+9INH8YX96FKWc5tie0QixWz6tOqAsAKfcJyPkE0xPep+NDz0IQLR32q4bn10QK3LqD2HN6T3n6z1YLW7Q=="],
 
     "language-subtag-registry": ["language-subtag-registry@0.3.23", "", {}, "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ=="],
 
@@ -1344,6 +1520,8 @@
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
     "libsql": ["libsql@0.5.22", "", { "dependencies": { "@neon-rs/load": "^0.0.4", "detect-libc": "2.0.2" }, "optionalDependencies": { "@libsql/darwin-arm64": "0.5.22", "@libsql/darwin-x64": "0.5.22", "@libsql/linux-arm-gnueabihf": "0.5.22", "@libsql/linux-arm-musleabihf": "0.5.22", "@libsql/linux-arm64-gnu": "0.5.22", "@libsql/linux-arm64-musl": "0.5.22", "@libsql/linux-x64-gnu": "0.5.22", "@libsql/linux-x64-musl": "0.5.22", "@libsql/win32-x64-msvc": "0.5.22" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "arm", "x64", "arm64", ] }, "sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA=="],
+
+    "lighthouse-logger": ["lighthouse-logger@2.0.2", "", { "dependencies": { "debug": "^4.4.1", "marky": "^1.2.2" } }, "sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg=="],
 
     "lightningcss": ["lightningcss@1.30.2", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.30.2", "lightningcss-darwin-arm64": "1.30.2", "lightningcss-darwin-x64": "1.30.2", "lightningcss-freebsd-x64": "1.30.2", "lightningcss-linux-arm-gnueabihf": "1.30.2", "lightningcss-linux-arm64-gnu": "1.30.2", "lightningcss-linux-arm64-musl": "1.30.2", "lightningcss-linux-x64-gnu": "1.30.2", "lightningcss-linux-x64-musl": "1.30.2", "lightningcss-win32-arm64-msvc": "1.30.2", "lightningcss-win32-x64-msvc": "1.30.2" } }, "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ=="],
 
@@ -1385,6 +1563,8 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "marky": ["marky@1.3.0", "", {}, "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "mdn-data": ["mdn-data@2.12.2", "", {}, "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA=="],
@@ -1415,9 +1595,13 @@
 
     "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
+    "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "msw": ["msw@2.11.6", "", { "dependencies": { "@inquirer/confirm": "^5.0.0", "@mswjs/interceptors": "^0.40.0", "@open-draft/deferred-promise": "^2.2.0", "@types/statuses": "^2.0.4", "cookie": "^1.0.2", "graphql": "^16.8.1", "headers-polyfill": "^4.0.2", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "path-to-regexp": "^6.3.0", "picocolors": "^1.1.1", "rettime": "^0.7.0", "statuses": "^2.0.2", "strict-event-emitter": "^0.5.1", "tough-cookie": "^6.0.0", "type-fest": "^4.26.1", "until-async": "^3.0.2", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": ">= 4.8.x" }, "optionalPeers": ["typescript"], "bin": { "msw": "cli/index.js" } }, "sha512-MCYMykvmiYScyUm7I6y0VCxpNq1rgd5v7kG8ks5dKtvmxRUUPjribX6mUoUNBbM5/3PhUyoelEWiKXGOz84c+w=="],
+
+    "mustache": ["mustache@4.2.0", "", { "bin": { "mustache": "bin/mustache" } }, "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="],
 
     "mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
 
@@ -1431,6 +1615,8 @@
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
+    "netmask": ["netmask@2.0.2", "", {}, "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="],
+
     "next": ["next@16.0.10", "", { "dependencies": { "@next/env": "16.0.10", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.0.10", "@next/swc-darwin-x64": "16.0.10", "@next/swc-linux-arm64-gnu": "16.0.10", "@next/swc-linux-arm64-musl": "16.0.10", "@next/swc-linux-x64-gnu": "16.0.10", "@next/swc-linux-x64-musl": "16.0.10", "@next/swc-win32-arm64-msvc": "16.0.10", "@next/swc-win32-x64-msvc": "16.0.10", "sharp": "^0.34.4" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-RtWh5PUgI+vxlV3HdR+IfWA1UUHu0+Ram/JBO4vWB54cVPentCD0e+lxyAYEsDTqGGMg7qpjhKh6dc6aW7W/sA=="],
 
     "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
@@ -1438,6 +1624,8 @@
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
     "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
+    "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
 
     "node-releases": ["node-releases@2.0.26", "", {}, "sha512-S2M9YimhSjBSvYnlr5/+umAnPHE++ODwt5e2Ij6FoX45HA/s4vHdkDx1eax2pAPeAOqu4s9b7ppahsyEFdVqQA=="],
 
@@ -1461,6 +1649,8 @@
 
     "object.values": ["object.values@1.2.1", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA=="],
 
+    "ollama-ai-provider-v2": ["ollama-ai-provider-v2@1.5.5", "", { "dependencies": { "@ai-sdk/provider": "^2.0.0", "@ai-sdk/provider-utils": "^3.0.17" }, "peerDependencies": { "zod": "^4.0.16" } }, "sha512-1YwTFdPjhPNHny/DrOHO+s8oVGGIE5Jib61/KnnjPRNWQhVVimrJJdaAX3e6nNRRDXrY5zbb9cfm2+yVvgsrqw=="],
+
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
@@ -1468,6 +1658,8 @@
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
+
+    "openai": ["openai@4.104.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" }, "peerDependencies": { "ws": "^8.18.0", "zod": "^3.23.8" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
@@ -1477,9 +1669,21 @@
 
     "own-keys": ["own-keys@1.0.1", "", { "dependencies": { "get-intrinsic": "^1.2.6", "object-keys": "^1.1.1", "safe-push-apply": "^1.0.0" } }, "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg=="],
 
+    "p-finally": ["p-finally@1.0.0", "", {}, "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="],
+
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "p-queue": ["p-queue@6.6.2", "", { "dependencies": { "eventemitter3": "^4.0.4", "p-timeout": "^3.2.0" } }, "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ=="],
+
+    "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
+    "p-timeout": ["p-timeout@3.2.0", "", { "dependencies": { "p-finally": "^1.0.0" } }, "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg=="],
+
+    "pac-proxy-agent": ["pac-proxy-agent@7.2.0", "", { "dependencies": { "@tootallnate/quickjs-emscripten": "^0.23.0", "agent-base": "^7.1.2", "debug": "^4.3.4", "get-uri": "^6.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.6", "pac-resolver": "^7.0.1", "socks-proxy-agent": "^8.0.5" } }, "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA=="],
+
+    "pac-resolver": ["pac-resolver@7.0.1", "", { "dependencies": { "degenerator": "^5.0.0", "netmask": "^2.0.2" } }, "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg=="],
 
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
 
@@ -1495,6 +1699,8 @@
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
+    "patchright-core": ["patchright-core@1.57.0", "", { "bin": { "patchright-core": "cli.js" } }, "sha512-um/9Wue7IFAa9UDLacjNgDn62ub5GJe1b1qouvYpELIF9rsFVMNhRo/rRXYajupLwp5xKJ0sSjOV6sw8/HarBQ=="],
+
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
@@ -1509,13 +1715,17 @@
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
+    "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
-    "pino": ["pino@10.1.0", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-0zZC2ygfdqvqK8zJIr1e+wT1T/L+LF6qvqvbzEQ6tiMAoTqEVK9a1K3YRu8HEUvGEvNqZyPJTtb2sNIoTkB83w=="],
+    "pino": ["pino@9.14.0", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w=="],
 
     "pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
+
+    "pino-pretty": ["pino-pretty@13.1.3", "", { "dependencies": { "colorette": "^2.0.7", "dateformat": "^4.6.3", "fast-copy": "^4.0.0", "fast-safe-stringify": "^2.1.1", "help-me": "^5.0.0", "joycon": "^3.1.1", "minimist": "^1.2.6", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pump": "^3.0.0", "secure-json-parse": "^4.0.0", "sonic-boom": "^4.0.1", "strip-json-comments": "^5.0.2" }, "bin": { "pino-pretty": "bin.js" } }, "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg=="],
 
     "pino-std-serializers": ["pino-std-serializers@7.0.0", "", {}, "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA=="],
 
@@ -1535,6 +1745,8 @@
 
     "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
 
+    "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
+
     "promise-limit": ["promise-limit@2.7.0", "", {}, "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw=="],
 
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
@@ -1543,7 +1755,15 @@
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
+    "proxy-agent": ["proxy-agent@6.5.0", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "http-proxy-agent": "^7.0.1", "https-proxy-agent": "^7.0.6", "lru-cache": "^7.14.1", "pac-proxy-agent": "^7.1.0", "proxy-from-env": "^1.1.0", "socks-proxy-agent": "^8.0.5" } }, "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
+    "pump": ["pump@3.0.3", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA=="],
+
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "puppeteer-core": ["puppeteer-core@22.15.0", "", { "dependencies": { "@puppeteer/browsers": "2.3.0", "chromium-bidi": "0.6.3", "debug": "^4.3.6", "devtools-protocol": "0.0.1312386", "ws": "^8.18.0" } }, "sha512-cHArnywCiAAVXa3t4GGL2vttNxh7GqXtIYGym99egkNJ3oG//wL9LkvO4WE8W1TJe95t1F1ocu9X4xWaGsOKOA=="],
 
     "pvtsutils": ["pvtsutils@1.3.6", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
 
@@ -1601,9 +1821,13 @@
 
     "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
     "rettime": ["rettime@0.7.0", "", {}, "sha512-LPRKoHnLKd/r3dVxcwO7vhCW+orkOGj9ViueosEBK6ie89CijnfRlhaDhHq/3Hxu4CkWQtxwlBG0mzTQY6uQjw=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "rimraf": ["rimraf@5.0.10", "", { "dependencies": { "glob": "^10.3.7" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ=="],
 
     "rollup": ["rollup@4.52.5", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.52.5", "@rollup/rollup-android-arm64": "4.52.5", "@rollup/rollup-darwin-arm64": "4.52.5", "@rollup/rollup-darwin-x64": "4.52.5", "@rollup/rollup-freebsd-arm64": "4.52.5", "@rollup/rollup-freebsd-x64": "4.52.5", "@rollup/rollup-linux-arm-gnueabihf": "4.52.5", "@rollup/rollup-linux-arm-musleabihf": "4.52.5", "@rollup/rollup-linux-arm64-gnu": "4.52.5", "@rollup/rollup-linux-arm64-musl": "4.52.5", "@rollup/rollup-linux-loong64-gnu": "4.52.5", "@rollup/rollup-linux-ppc64-gnu": "4.52.5", "@rollup/rollup-linux-riscv64-gnu": "4.52.5", "@rollup/rollup-linux-riscv64-musl": "4.52.5", "@rollup/rollup-linux-s390x-gnu": "4.52.5", "@rollup/rollup-linux-x64-gnu": "4.52.5", "@rollup/rollup-linux-x64-musl": "4.52.5", "@rollup/rollup-openharmony-arm64": "4.52.5", "@rollup/rollup-win32-arm64-msvc": "4.52.5", "@rollup/rollup-win32-ia32-msvc": "4.52.5", "@rollup/rollup-win32-x64-gnu": "4.52.5", "@rollup/rollup-win32-x64-msvc": "4.52.5", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw=="],
 
@@ -1630,6 +1854,8 @@
     "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -1669,7 +1895,15 @@
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
+    "simple-wcswidth": ["simple-wcswidth@1.1.2", "", {}, "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw=="],
+
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
+
+    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
+    "socks": ["socks@2.8.7", "", { "dependencies": { "ip-address": "^10.0.1", "smart-buffer": "^4.2.0" } }, "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A=="],
+
+    "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
 
     "sonic-boom": ["sonic-boom@4.2.0", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww=="],
 
@@ -1694,6 +1928,8 @@
     "stdin-discarder": ["stdin-discarder@0.2.2", "", {}, "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="],
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
+
+    "streamx": ["streamx@2.23.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg=="],
 
     "strict-event-emitter": ["strict-event-emitter@0.5.1", "", {}, "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ=="],
 
@@ -1741,7 +1977,15 @@
 
     "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
 
+    "tar-fs": ["tar-fs@3.1.1", "", { "dependencies": { "pump": "^3.0.0", "tar-stream": "^3.1.5" }, "optionalDependencies": { "bare-fs": "^4.0.1", "bare-path": "^3.0.0" } }, "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg=="],
+
+    "tar-stream": ["tar-stream@3.1.7", "", { "dependencies": { "b4a": "^1.6.4", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ=="],
+
+    "text-decoder": ["text-decoder@1.2.3", "", { "dependencies": { "b4a": "^1.6.4" } }, "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA=="],
+
     "thread-stream": ["thread-stream@3.1.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A=="],
+
+    "through": ["through@2.3.8", "", {}, "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="],
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
@@ -1799,6 +2043,8 @@
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 
+    "unbzip2-stream": ["unbzip2-stream@1.4.3", "", { "dependencies": { "buffer": "^5.2.1", "through": "^2.3.8" } }, "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg=="],
+
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
@@ -1817,11 +2063,15 @@
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
+    "urlpattern-polyfill": ["urlpattern-polyfill@10.0.0", "", {}, "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg=="],
+
     "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
 
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
+    "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
@@ -1877,21 +2127,85 @@
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
+    "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
+
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
 
     "yoctocolors-cjs": ["yoctocolors-cjs@2.1.3", "", {}, "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw=="],
 
-    "zod": ["zod@4.1.12", "", {}, "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ=="],
+    "zod": ["zod@4.3.5", "", {}, "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.24.6", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg=="],
 
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
 
+    "@ai-sdk/anthropic/@ai-sdk/provider": ["@ai-sdk/provider@2.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng=="],
+
+    "@ai-sdk/anthropic/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.20", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-iXHVe0apM2zUEzauqJwqmpC37A5rihrStAih5Ks+JE32iTe4LZ58y17UGBjpQQTCRw9YxMeo2UFLxLpBluyvLQ=="],
+
+    "@ai-sdk/azure/@ai-sdk/openai": ["@ai-sdk/openai@2.0.89", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@ai-sdk/provider-utils": "3.0.20" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-4+qWkBCbL9HPKbgrUO/F2uXZ8GqrYxHa8SWEYIzxEJ9zvWw3ISr3t1/27O1i8MGSym+PzEyHBT48EV4LAwWaEw=="],
+
+    "@ai-sdk/azure/@ai-sdk/provider": ["@ai-sdk/provider@2.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng=="],
+
+    "@ai-sdk/azure/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.20", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-iXHVe0apM2zUEzauqJwqmpC37A5rihrStAih5Ks+JE32iTe4LZ58y17UGBjpQQTCRw9YxMeo2UFLxLpBluyvLQ=="],
+
+    "@ai-sdk/cerebras/@ai-sdk/provider": ["@ai-sdk/provider@2.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng=="],
+
+    "@ai-sdk/cerebras/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.20", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-iXHVe0apM2zUEzauqJwqmpC37A5rihrStAih5Ks+JE32iTe4LZ58y17UGBjpQQTCRw9YxMeo2UFLxLpBluyvLQ=="],
+
+    "@ai-sdk/deepseek/@ai-sdk/provider": ["@ai-sdk/provider@2.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng=="],
+
+    "@ai-sdk/deepseek/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.20", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-iXHVe0apM2zUEzauqJwqmpC37A5rihrStAih5Ks+JE32iTe4LZ58y17UGBjpQQTCRw9YxMeo2UFLxLpBluyvLQ=="],
+
+    "@ai-sdk/google/@ai-sdk/provider": ["@ai-sdk/provider@2.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng=="],
+
+    "@ai-sdk/google/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.20", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-iXHVe0apM2zUEzauqJwqmpC37A5rihrStAih5Ks+JE32iTe4LZ58y17UGBjpQQTCRw9YxMeo2UFLxLpBluyvLQ=="],
+
+    "@ai-sdk/google-vertex/@ai-sdk/provider": ["@ai-sdk/provider@2.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng=="],
+
+    "@ai-sdk/google-vertex/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.20", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-iXHVe0apM2zUEzauqJwqmpC37A5rihrStAih5Ks+JE32iTe4LZ58y17UGBjpQQTCRw9YxMeo2UFLxLpBluyvLQ=="],
+
+    "@ai-sdk/groq/@ai-sdk/provider": ["@ai-sdk/provider@2.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng=="],
+
+    "@ai-sdk/groq/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.20", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-iXHVe0apM2zUEzauqJwqmpC37A5rihrStAih5Ks+JE32iTe4LZ58y17UGBjpQQTCRw9YxMeo2UFLxLpBluyvLQ=="],
+
+    "@ai-sdk/mistral/@ai-sdk/provider": ["@ai-sdk/provider@2.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng=="],
+
+    "@ai-sdk/mistral/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.20", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-iXHVe0apM2zUEzauqJwqmpC37A5rihrStAih5Ks+JE32iTe4LZ58y17UGBjpQQTCRw9YxMeo2UFLxLpBluyvLQ=="],
+
+    "@ai-sdk/openai-compatible/@ai-sdk/provider": ["@ai-sdk/provider@2.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng=="],
+
+    "@ai-sdk/openai-compatible/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.20", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-iXHVe0apM2zUEzauqJwqmpC37A5rihrStAih5Ks+JE32iTe4LZ58y17UGBjpQQTCRw9YxMeo2UFLxLpBluyvLQ=="],
+
+    "@ai-sdk/perplexity/@ai-sdk/provider": ["@ai-sdk/provider@2.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng=="],
+
+    "@ai-sdk/perplexity/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.20", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-iXHVe0apM2zUEzauqJwqmpC37A5rihrStAih5Ks+JE32iTe4LZ58y17UGBjpQQTCRw9YxMeo2UFLxLpBluyvLQ=="],
+
+    "@ai-sdk/togetherai/@ai-sdk/provider": ["@ai-sdk/provider@2.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng=="],
+
+    "@ai-sdk/togetherai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.20", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-iXHVe0apM2zUEzauqJwqmpC37A5rihrStAih5Ks+JE32iTe4LZ58y17UGBjpQQTCRw9YxMeo2UFLxLpBluyvLQ=="],
+
+    "@ai-sdk/xai/@ai-sdk/provider": ["@ai-sdk/provider@2.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng=="],
+
+    "@ai-sdk/xai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.20", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-iXHVe0apM2zUEzauqJwqmpC37A5rihrStAih5Ks+JE32iTe4LZ58y17UGBjpQQTCRw9YxMeo2UFLxLpBluyvLQ=="],
+
     "@antfu/ni/tinyexec": ["tinyexec@1.0.1", "", {}, "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw=="],
 
+    "@anthropic-ai/sdk/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
+
+    "@anthropic-ai/sdk/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "@better-auth/core/zod": ["zod@4.1.12", "", {}, "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ=="],
+
+    "@browserbasehq/sdk/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
+
+    "@browserbasehq/sdk/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
+    "@browserbasehq/stagehand/zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
     "@dotenvx/dotenvx/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
@@ -1915,11 +2229,25 @@
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
+    "@langchain/core/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "@langchain/core/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
+
+    "@langchain/core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@langchain/core/zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
+
+    "@langchain/openai/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@langchain/openai/zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
+
     "@modelcontextprotocol/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@next/eslint-plugin-next/fast-glob": ["fast-glob@3.3.1", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.4" } }, "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg=="],
 
     "@noble/curves/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "@puppeteer/browsers/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.6.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-zq/ay+9fNIJJtJiZxdTnXS20PllcYMX3OE23ESc4HK/bdYu3cOWYVhsOhVnXALfU/uqJIxn5NBPd9z4v+SfoSg=="],
 
@@ -1941,11 +2269,17 @@
 
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
+    "better-auth/zod": ["zod@4.1.12", "", {}, "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ=="],
+
+    "chromium-bidi/zod": ["zod@3.23.8", "", {}, "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g=="],
+
     "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "degenerator/ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
 
     "eciesjs/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
@@ -1961,15 +2295,29 @@
 
     "eslint-plugin-react/resolve": ["resolve@2.0.0-next.5", "", { "dependencies": { "is-core-module": "^2.13.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA=="],
 
+    "eslint-plugin-react-hooks/zod": ["zod@4.1.12", "", {}, "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ=="],
+
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
+    "extract-zip/get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
+
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "formdata-node/web-streams-polyfill": ["web-streams-polyfill@4.0.0-beta.3", "", {}, "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="],
+
+    "get-uri/data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
 
     "glob/minimatch": ["minimatch@10.1.1", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.0" } }, "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ=="],
 
     "http-errors/statuses": ["statuses@2.0.1", "", {}, "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="],
 
     "is-bun-module/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "langsmith/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "langsmith/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
     "lightningcss/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
@@ -1983,13 +2331,31 @@
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
+    "ollama-ai-provider-v2/@ai-sdk/provider": ["@ai-sdk/provider@2.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng=="],
+
+    "ollama-ai-provider-v2/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.20", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-iXHVe0apM2zUEzauqJwqmpC37A5rihrStAih5Ks+JE32iTe4LZ58y17UGBjpQQTCRw9YxMeo2UFLxLpBluyvLQ=="],
+
+    "openai/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
+
+    "openai/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
     "ora/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
+    "pino-pretty/pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
+
+    "pino-pretty/strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
+
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
+
+    "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
+
+    "puppeteer-core/devtools-protocol": ["devtools-protocol@0.0.1312386", "", {}, "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA=="],
 
     "raw-body/iconv-lite": ["iconv-lite@0.7.0", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ=="],
 
     "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
+
+    "rimraf/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
     "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -2022,6 +2388,14 @@
     "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "@anthropic-ai/sdk/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
+
+    "@anthropic-ai/sdk/node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
+
+    "@browserbasehq/sdk/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
+
+    "@browserbasehq/sdk/node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "@dotenvx/dotenvx/execa/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
 
@@ -2095,6 +2469,18 @@
 
     "eslint-plugin-import/tsconfig-paths/json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": { "json5": "lib/cli.js" } }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
 
+    "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "openai/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
+
+    "openai/node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
+
+    "rimraf/glob/jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+
+    "rimraf/glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "rimraf/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
     "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
@@ -2105,9 +2491,25 @@
 
     "yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "@anthropic-ai/sdk/node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
+    "@anthropic-ai/sdk/node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "@browserbasehq/sdk/node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
+    "@browserbasehq/sdk/node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
     "@inquirer/core/wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "@inquirer/core/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "openai/node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
+    "openai/node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "rimraf/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "rimraf/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }

--- a/lib/spec-test/README.md
+++ b/lib/spec-test/README.md
@@ -1,0 +1,376 @@
+# spec-test Library
+
+A specification-driven testing library that parses **product behavior specifications** (Epic Specification Format) and executes them as browser tests using AI-powered automation.
+
+## Overview
+
+The spec-test library bridges the gap between product specifications and automated testing. Instead of writing separate test files, you write behavior specifications for your product, and this library executes them directly against your running application.
+
+```
+Product Spec (Markdown) --> Parser --> Browser Automation --> Results
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        spec-test Library                        │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  ┌──────────────┐    ┌──────────────┐    ┌──────────────┐      │
+│  │ parseSpecFile│───>│SpecTestRunner│───>│ ExampleResult│      │
+│  │              │    │              │    │              │      │
+│  │ - name       │    │ - runExample │    │ - success    │      │
+│  │ - directory  │    │ - runStep    │    │ - steps      │      │
+│  │ - examples[] │    │              │    │ - failedAt   │      │
+│  └──────────────┘    └──────┬───────┘    └──────────────┘      │
+│                             │                                   │
+│              ┌──────────────┴──────────────┐                   │
+│              │                             │                   │
+│       ┌──────▼──────┐             ┌────────▼────────┐          │
+│       │  Stagehand  │             │     B-Test      │          │
+│       │ (Act steps) │             │ (Check steps)   │          │
+│       │             │             │                 │          │
+│       │ AI-powered  │             │ Snapshot diff   │          │
+│       │ browser     │             │ LLM assertions  │          │
+│       │ automation  │             │                 │          │
+│       └─────────────┘             └─────────────────┘          │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Epic Specification Format
+
+The library parses markdown files written in the Epic Specification Format:
+
+```markdown
+# Behavior Name
+
+Description of the behavior.
+
+Directory: `app/(app)/behaviors/feature-name/`
+
+## Examples
+
+### Example scenario name
+
+#### Steps
+* Act: User performs some action
+* Act: User fills in "value" in field name
+* Check: URL contains /expected-path
+* Check: Success message is displayed
+```
+
+### Structure
+
+| Element | Description |
+|---------|-------------|
+| `# H1` | Behavior name |
+| `Directory:` | Optional path to implementation |
+| `## Examples` | Section containing test scenarios |
+| `### H3` | Example name |
+| `#### Steps` | Steps section for an example |
+| `* Act:` | Action to perform (uses Stagehand) |
+| `* Check:` | Verification to assert (uses B-Test) |
+
+## Step Types
+
+### Act Steps
+
+Act steps describe user actions in natural language. They are executed using [Stagehand](https://github.com/browserbase/stagehand), an AI-powered browser automation tool.
+
+```markdown
+* Act: User clicks the Login button
+* Act: User enters "user@example.com" in email field
+* Act: User selects "Admin" from the role dropdown
+* Act: User scrolls to the bottom of the page
+```
+
+Stagehand understands natural language and finds elements intelligently - no selectors needed.
+
+### Check Steps
+
+Check steps verify the application state. They are classified as either **deterministic** or **semantic**.
+
+#### Deterministic Checks
+
+These are verified directly using Playwright assertions (fast, no AI):
+
+```markdown
+* Check: URL contains /dashboard
+* Check: URL is https://example.com/home
+* Check: Page title is "Dashboard"
+* Check: Page title contains "Welcome"
+```
+
+Supported patterns:
+- `URL contains X`
+- `URL is X`
+- `Page title is X`
+- `Page title contains X`
+
+#### Semantic Checks
+
+All other checks use [B-Test](../b-test/README.md) for LLM-powered assertions:
+
+```markdown
+* Check: Success notification is displayed
+* Check: Error message shows "Invalid credentials"
+* Check: New project appears in the list
+* Check: User avatar is visible in the header
+```
+
+B-Test takes snapshots before/after actions and uses an LLM to verify conditions.
+
+## Usage
+
+### Programmatic Usage
+
+```typescript
+import { SpecTestRunner, parseSpecFile } from '@/lib/spec-test';
+
+// Create runner
+const runner = new SpecTestRunner({
+  baseUrl: 'http://localhost:8080',
+  headless: true,
+});
+
+// Run all examples from a spec file
+const result = await runner.runFromFile('./docs/specs/login.md');
+
+// Or run a specific example
+const result = await runner.runFromFile(
+  './docs/specs/login.md',
+  'Login with valid credentials'
+);
+
+// Check results
+if (result.success) {
+  console.log('All examples passed!');
+} else {
+  result.exampleResults.forEach(example => {
+    if (!example.success) {
+      console.log(`Failed: ${example.example.name}`);
+      console.log(`Error: ${example.failedAt?.context.error}`);
+    }
+  });
+}
+
+await runner.close();
+```
+
+### Manual Test Runner
+
+Use the CLI runner for interactive testing:
+
+```bash
+# Run with default spec
+bun lib/spec-test/tests/run-spec.ts
+
+# Run specific spec file
+bun lib/spec-test/tests/run-spec.ts docs/specs/create-project.md
+
+# Run specific example from spec
+bun lib/spec-test/tests/run-spec.ts docs/specs/login.md "Login with email"
+
+# With custom base URL
+BASE_URL=http://localhost:3000 bun lib/spec-test/tests/run-spec.ts
+```
+
+### Integration Tests
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { SpecTestRunner } from '@/lib/spec-test';
+
+describe('Login Behavior', () => {
+  let runner: SpecTestRunner;
+
+  beforeAll(() => {
+    runner = new SpecTestRunner({
+      baseUrl: 'http://localhost:8080',
+      headless: true,
+    });
+  });
+
+  afterAll(() => runner.close());
+
+  it('should login with valid credentials', async () => {
+    const result = await runner.runFromFile(
+      './docs/specs/login.md',
+      'Login with valid credentials'
+    );
+    expect(result.success).toBe(true);
+  }, 60000);
+});
+```
+
+## Configuration
+
+### SpecTestConfig
+
+```typescript
+interface SpecTestConfig {
+  /** Base URL of the application under test */
+  baseUrl: string;
+
+  /** Use headless browser (default: true) */
+  headless?: boolean;
+
+  /** B-Test AI model override */
+  aiModel?: LanguageModelV2;
+
+  /** Browserbase API key for cloud execution */
+  browserbaseApiKey?: string;
+
+  /** Additional Stagehand options */
+  stagehandOptions?: Record<string, unknown>;
+}
+```
+
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `OPENAI_API_KEY` | Required for Stagehand and semantic checks |
+| `BASE_URL` | Override default application URL |
+| `BROWSERBASE_API_KEY` | For cloud browser execution |
+
+## Result Types
+
+### SpecTestResult
+
+```typescript
+interface SpecTestResult {
+  success: boolean;              // All examples passed
+  spec: TestableSpec;            // Parsed specification
+  exampleResults: ExampleResult[]; // Results per example
+  duration: number;              // Total duration in ms
+}
+```
+
+### ExampleResult
+
+```typescript
+interface ExampleResult {
+  example: SpecExample;          // Example that was run
+  success: boolean;              // Example passed
+  steps: StepResult[];           // Results per step
+  duration: number;              // Example duration in ms
+  failedAt?: {                   // Failure details
+    stepIndex: number;
+    step: SpecStep;
+    context: FailureContext;
+  };
+}
+```
+
+### FailureContext
+
+When a step fails, rich context is provided for debugging:
+
+```typescript
+interface FailureContext {
+  pageSnapshot: string;          // Full HTML snapshot
+  pageUrl: string;               // Current URL
+  failedStep: SpecStep;          // Step that failed
+  error: string;                 // Error message
+  availableElements: Array<{     // Interactive elements on page
+    type: string;
+    text?: string;
+    selector: string;
+  }>;
+  suggestions: string[];         // AI-generated fix suggestions
+}
+```
+
+## How It Works
+
+### Snapshot Lifecycle
+
+The library manages B-Test's snapshot lifecycle for correct diff-based assertions:
+
+1. **Initial snapshot** - Before any steps, capture baseline
+2. **Before Act** - Reset snapshots, take fresh "before" baseline
+3. **Execute Act** - Perform action, page state changes
+4. **Check step** - Take "after" snapshot, compare diff, assert condition
+
+```
+┌─────────┐     ┌─────────┐     ┌─────────┐     ┌─────────┐
+│ Initial │────>│  Act 1  │────>│ Check 1 │────>│  Act 2  │──> ...
+│snapshot │     │ reset + │     │ after + │     │ reset + │
+│         │     │snapshot │     │ assert  │     │snapshot │
+└─────────┘     └─────────┘     └─────────┘     └─────────┘
+```
+
+### Example Flow
+
+Given this spec:
+
+```markdown
+### Login with valid credentials
+
+#### Steps
+* Act: User enters "user@example.com" in email field
+* Act: User enters "password123" in password field
+* Act: User clicks Login button
+* Check: URL contains /dashboard
+```
+
+Execution:
+
+1. Navigate to `baseUrl`
+2. Take initial snapshot
+3. **Act 1**: Reset snapshots, snapshot, Stagehand fills email
+4. **Act 2**: Reset snapshots, snapshot, Stagehand fills password
+5. **Act 3**: Reset snapshots, snapshot, Stagehand clicks button
+6. **Check**: Take after snapshot, verify URL contains "/dashboard"
+
+## Dependencies
+
+- **Stagehand** (`@browserbasehq/stagehand`) - AI-powered browser automation for Act steps
+- **B-Test** (`@/lib/b-test`) - LLM-powered assertions for semantic Check steps
+- **Playwright** - Browser automation engine (used by Stagehand)
+
+## File Structure
+
+```
+lib/spec-test/
+├── index.ts          # Main implementation
+├── types.ts          # Type definitions
+├── README.md         # This file
+└── tests/
+    ├── run-spec.ts           # Manual CLI runner
+    ├── integration.test.ts   # Integration tests
+    └── fixtures/
+        ├── login-spec.md         # Sample spec
+        ├── login-failure-spec.md # Failure test spec
+        ├── login-page.html       # Test HTML page
+        └── dashboard-page.html   # Test HTML page
+```
+
+## Best Practices
+
+1. **Write specs first** - Define behavior before implementing
+2. **Use deterministic checks when possible** - Faster and more reliable
+3. **Keep examples focused** - One scenario per example
+4. **Use descriptive names** - Example names should describe the scenario
+5. **Test failure paths** - Include examples for error states
+
+## Troubleshooting
+
+### "Element not found"
+
+- Stagehand couldn't find the element. Check the failure context for available elements.
+- Try more specific language in the Act step.
+
+### Semantic check failing
+
+- The LLM couldn't verify the condition. Check if the condition is clear.
+- Consider using a deterministic check if possible.
+
+### Timeout errors
+
+- Increase timeout in test configuration.
+- Check if page is fully loaded before actions.
+- Verify the application is running at `baseUrl`.

--- a/lib/spec-test/index.ts
+++ b/lib/spec-test/index.ts
@@ -1,0 +1,729 @@
+import { readFile } from "fs/promises";
+import type { Page } from "playwright";
+import type { Stagehand } from "@browserbasehq/stagehand";
+import type { Tester } from "@/lib/b-test";
+
+// Re-export all types
+export type {
+  SpecTestConfig,
+  TestableSpec,
+  SpecExample,
+  SpecStep,
+  SpecTestResult,
+  ExampleResult,
+  StepResult,
+  ActResult,
+  CheckResult,
+  FailureContext,
+  StepContext,
+} from "./types";
+
+import type {
+  SpecTestConfig,
+  TestableSpec,
+  SpecExample,
+  SpecStep,
+  SpecTestResult,
+  ExampleResult,
+  StepResult,
+  ActResult,
+  CheckResult,
+  FailureContext,
+  StepContext,
+} from "./types";
+
+/**
+ * Regex pattern to match Act and Check step lines.
+ * Captures: (1) step type (Act|Check), (2) instruction text
+ */
+const STEP_PATTERN = /^\s*\*\s*(Act|Check):\s*(.+)$/;
+
+/**
+ * Parses the Steps section from markdown content into an array of executable steps.
+ *
+ * @param content - Markdown content containing Steps section with Act/Check lines
+ * @returns Array of SpecStep objects with type, instruction, and checkType
+ */
+export function parseSteps(content: string): SpecStep[] {
+  return content
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .flatMap((line, index): SpecStep[] => {
+      const match = line.match(STEP_PATTERN);
+      if (!match) return [];
+
+      const [, stepType, rawInstruction] = match;
+      const instruction = rawInstruction.trim();
+      const lineNumber = index + 1;
+
+      if (stepType === "Act") {
+        return [{ type: "act", instruction, lineNumber }];
+      }
+
+      return [{
+        type: "check",
+        instruction,
+        checkType: classifyCheck(instruction),
+        lineNumber,
+      }];
+    });
+}
+
+/** Regex pattern to extract behavior name from first H1 heading. */
+const NAME_PATTERN = /^#\s+(.+)$/m;
+
+/** Regex pattern to extract directory from Directory: line. */
+const DIRECTORY_PATTERN = /^Directory:\s*`([^`]+)`/m;
+
+/** Regex pattern to match example headings (H3 in Examples section). */
+const EXAMPLE_HEADING_PATTERN = /^###\s+(.+)$/gm;
+
+/**
+ * Parses the Examples section from Epic Specification Format.
+ *
+ * @param content - Full markdown content
+ * @returns Array of SpecExample objects with name and steps
+ */
+export function parseExamples(content: string): SpecExample[] {
+  // Find the ## Examples section
+  const examplesMatch = content.match(/^## Examples\s*$/m);
+  if (!examplesMatch) {
+    // Fallback: treat entire content as single unnamed example (legacy format)
+    const steps = parseSteps(content);
+    if (steps.length > 0) {
+      return [{ name: "Default", steps }];
+    }
+    return [];
+  }
+
+  const examplesStart = examplesMatch.index! + examplesMatch[0].length;
+
+  // Find where Examples section ends (next H2 or end of file)
+  const nextH2Match = content.slice(examplesStart).match(/^## [^#]/m);
+  const examplesEnd = nextH2Match
+    ? examplesStart + nextH2Match.index!
+    : content.length;
+
+  const examplesContent = content.slice(examplesStart, examplesEnd);
+  const examples: SpecExample[] = [];
+
+  // Split by H3 headings to get individual examples
+  const exampleMatches = [...examplesContent.matchAll(EXAMPLE_HEADING_PATTERN)];
+
+  for (let i = 0; i < exampleMatches.length; i++) {
+    const match = exampleMatches[i];
+    const exampleName = match[1].trim();
+    const exampleStart = match.index! + match[0].length;
+    const exampleEnd = exampleMatches[i + 1]?.index ?? examplesContent.length;
+    const exampleContent = examplesContent.slice(exampleStart, exampleEnd);
+
+    // Parse steps from #### Steps section
+    const steps = parseSteps(exampleContent);
+    if (steps.length > 0) {
+      examples.push({ name: exampleName, steps });
+    }
+  }
+
+  return examples;
+}
+
+/**
+ * Parses a behavior specification markdown file into a TestableSpec object.
+ *
+ * Epic Specification Format:
+ * - H1 = behavior name
+ * - `Directory:` = optional directory path
+ * - `## Examples` section contains named examples with `#### Steps`
+ *
+ * Also supports legacy format with Steps directly in content.
+ *
+ * @param filePath - Path to a markdown file with behavior specification
+ * @returns Promise resolving to TestableSpec with parsed name, directory, and examples
+ */
+export async function parseSpecFile(filePath: string): Promise<TestableSpec> {
+  const content = await readFile(filePath, "utf-8");
+
+  // Extract behavior name from H1
+  const nameMatch = content.match(NAME_PATTERN);
+  const name = nameMatch?.[1]?.trim() ?? "Unnamed";
+
+  // Extract optional directory
+  const dirMatch = content.match(DIRECTORY_PATTERN);
+  const directory = dirMatch?.[1]?.trim();
+
+  // Parse examples from Examples section
+  const examples = parseExamples(content);
+
+  return { name, directory, examples };
+}
+
+/**
+ * Deterministic patterns that can be verified with Playwright assertions.
+ * Case-insensitive matching.
+ */
+const DETERMINISTIC_PATTERNS = [
+  /^url\s+contains\s+/i,
+  /^url\s+is\s+/i,
+  /^page\s+title\s+is\s+/i,
+  /^page\s+title\s+contains\s+/i,
+  /^element\s+count\s+is\s+/i,
+  /^input\s+value\s+is\s+/i,
+  /^checkbox\s+is\s+checked/i,
+];
+
+/**
+ * Determines whether a check can be verified deterministically or requires LLM.
+ *
+ * @param instruction - Natural language check instruction
+ * @returns "deterministic" for URL/title/count checks, "semantic" otherwise
+ */
+export function classifyCheck(instruction: string): "deterministic" | "semantic" {
+  const trimmed = instruction.trim();
+
+  for (const pattern of DETERMINISTIC_PATTERNS) {
+    if (pattern.test(trimmed)) {
+      return "deterministic";
+    }
+  }
+  return "semantic";
+}
+
+/**
+ * Executes an Act step using Stagehand natural language browser automation.
+ *
+ * @param instruction - Natural language action instruction
+ * @param stagehand - Stagehand instance for browser automation
+ * @returns Promise resolving to ActResult with success status, timing, and page state
+ */
+export async function executeActStep(
+  instruction: string,
+  stagehand: Stagehand
+): Promise<ActResult> {
+  const startTime = Date.now();
+
+  try {
+    await stagehand.act(instruction);
+    const duration = Date.now() - startTime;
+    const page = stagehand.context.activePage();
+    const pageUrl = page?.url() ?? "";
+
+    return {
+      success: true,
+      duration,
+      pageUrl,
+    };
+  } catch (error) {
+    const duration = Date.now() - startTime;
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    const page = stagehand.context.activePage();
+    const pageSnapshot = page
+      ? await page.evaluate(() => document.documentElement.outerHTML)
+      : "";
+    const observations = await stagehand.observe();
+    const availableActions = observations.map((obs) => obs.description);
+
+    return {
+      success: false,
+      duration,
+      error: errorMessage,
+      pageSnapshot,
+      availableActions,
+    };
+  }
+}
+
+/** Pattern handlers for deterministic checks */
+const DETERMINISTIC_HANDLERS: Array<{
+  pattern: RegExp;
+  getActual: (page: Page) => string | Promise<string>;
+  compare: (actual: string, expected: string) => boolean;
+}> = [
+  {
+    pattern: /^url\s+contains\s+(.+)$/i,
+    getActual: (page) => page.url(),
+    compare: (actual, expected) => actual.includes(expected),
+  },
+  {
+    pattern: /^url\s+is\s+(.+)$/i,
+    getActual: (page) => page.url(),
+    compare: (actual, expected) => actual === expected,
+  },
+  {
+    pattern: /^page\s+title\s+is\s+(.+)$/i,
+    getActual: (page) => page.title(),
+    compare: (actual, expected) => actual === expected,
+  },
+  {
+    pattern: /^page\s+title\s+contains\s+(.+)$/i,
+    getActual: (page) => page.title(),
+    compare: (actual, expected) => actual.includes(expected),
+  },
+];
+
+/**
+ * Executes a Check step using either deterministic Playwright assertions or LLM-powered B-Test.
+ *
+ * @param instruction - Check instruction to verify
+ * @param checkType - "deterministic" or "semantic"
+ * @param page - Playwright page instance
+ * @param tester - B-Test Tester instance
+ * @returns Promise resolving to CheckResult with pass/fail, expected, actual, and reasoning
+ */
+export async function executeCheckStep(
+  instruction: string,
+  checkType: "deterministic" | "semantic",
+  page: Page,
+  tester: Tester
+): Promise<CheckResult> {
+  if (checkType === "deterministic") {
+    return executeDeterministicCheck(instruction, page);
+  }
+  return executeSemanticCheck(instruction, page, tester);
+}
+
+/**
+ * Executes a deterministic check using direct page state comparison.
+ */
+async function executeDeterministicCheck(
+  instruction: string,
+  page: Page
+): Promise<CheckResult> {
+  const trimmed = instruction.trim();
+
+  for (const handler of DETERMINISTIC_HANDLERS) {
+    const match = trimmed.match(handler.pattern);
+    if (match) {
+      const expected = match[1].trim();
+      const actual = await handler.getActual(page);
+      const passed = handler.compare(actual, expected);
+      return { passed, checkType: "deterministic", expected, actual };
+    }
+  }
+
+  return {
+    passed: false,
+    checkType: "deterministic",
+    expected: instruction,
+    actual: "Unrecognized check pattern",
+    suggestion: "Use patterns like 'URL contains X' or 'Page title is Y'",
+  };
+}
+
+/**
+ * Executes a semantic check using B-Test's LLM-powered assertions.
+ *
+ * IMPORTANT: Snapshot Lifecycle
+ * -----------------------------
+ * B-Test's assert() compares a DIFF between "before" and "after" snapshots.
+ * This function takes the "after" snapshot and expects that a "before" snapshot
+ * already exists from a previous step.
+ *
+ * The SpecTestRunner manages this lifecycle:
+ * 1. Initial snapshot before any steps (becomes first "before")
+ * 2. Before each Act step: reset + snapshot (new "before" baseline)
+ * 3. Check steps: this function takes "after" snapshot, then asserts
+ *
+ * Example flow:
+ *   Initial: snapshot()       → before = page0
+ *   Act: reset + snapshot()   → before = page0 (refreshed baseline)
+ *   Act: execute action       → page changes to page1
+ *   Check: snapshot()         → after = page1
+ *   Check: assert()           → compares page0 vs page1
+ *
+ * @param instruction - Natural language condition to verify
+ * @param page - Playwright page instance
+ * @param tester - B-Test Tester instance (must have "before" snapshot set)
+ * @returns Promise resolving to CheckResult
+ */
+async function executeSemanticCheck(
+  instruction: string,
+  page: Page,
+  tester: Tester
+): Promise<CheckResult> {
+  // Take "after" snapshot - "before" must already exist from SpecTestRunner
+  await tester.snapshot(page);
+  const passed = await tester.assert(instruction);
+
+  return {
+    passed,
+    checkType: "semantic",
+    expected: instruction,
+    actual: passed ? "Condition met" : "Condition not met",
+    reasoning: passed
+      ? `LLM confirmed: "${instruction}"`
+      : `LLM could not confirm: "${instruction}"`,
+  };
+}
+
+/**
+ * Generates rich failure context for agent self-correction.
+ *
+ * @param page - Current Playwright page state
+ * @param step - The step that failed
+ * @param error - The error that occurred
+ * @returns Promise resolving to FailureContext with snapshot, available actions, and suggestions
+ */
+export async function generateFailureContext(
+  page: Page,
+  step: SpecStep,
+  error: Error
+): Promise<FailureContext> {
+  const pageUrl = page.url();
+  const pageSnapshot = await page.evaluate(() => document.documentElement.outerHTML);
+  const availableElements = await extractInteractiveElements(page);
+  const suggestions = generateSuggestions(error, step, availableElements);
+
+  return {
+    pageSnapshot,
+    pageUrl,
+    failedStep: step,
+    error: error.message,
+    availableElements,
+    suggestions,
+  };
+}
+
+/**
+ * Extracts interactive elements from the page for debugging context.
+ */
+async function extractInteractiveElements(
+  page: Page
+): Promise<FailureContext["availableElements"]> {
+  return page.evaluate(() => {
+    const selectors = "button, a, input, select, textarea";
+    const elements = document.querySelectorAll(selectors);
+
+    return Array.from(elements).slice(0, 20).map((el) => {
+      const tagName = el.tagName.toLowerCase();
+      const type = tagName === "a" ? "link" : tagName;
+      const text = el.textContent?.trim().slice(0, 50) || "";
+
+      // Build selector
+      let selector = tagName;
+      if (el.id) {
+        selector += `#${el.id}`;
+      } else if (el.className && typeof el.className === "string") {
+        selector += `.${el.className.split(" ")[0]}`;
+      } else if (el.getAttribute("name")) {
+        selector += `[name='${el.getAttribute("name")}']`;
+      }
+
+      // Extract relevant attributes
+      const attributes: Record<string, string> = {};
+      for (const attr of ["type", "name", "placeholder", "href", "value"]) {
+        const value = el.getAttribute(attr);
+        if (value) attributes[attr] = value;
+      }
+
+      return {
+        type,
+        text: text || undefined,
+        selector,
+        ...(Object.keys(attributes).length > 0 ? { attributes } : {}),
+      };
+    });
+  });
+}
+
+/**
+ * Generates helpful suggestions based on error type and available elements.
+ */
+function generateSuggestions(
+  error: Error,
+  step: SpecStep,
+  elements: FailureContext["availableElements"]
+): string[] {
+  const suggestions: string[] = [];
+  const errorLower = error.message.toLowerCase();
+
+  if (errorLower.includes("not found") || errorLower.includes("no element")) {
+    suggestions.push(`Element not found for: "${step.instruction}"`);
+
+    const relevantElements = elements.filter((el) =>
+      el.type === "button" || el.type === "link"
+    );
+    if (relevantElements.length > 0) {
+      const names = relevantElements.map((el) => el.text || el.selector).slice(0, 5);
+      suggestions.push(`Available clickable elements: ${names.join(", ")}`);
+    }
+
+    suggestions.push("Try using more specific text or check if element exists");
+  }
+
+  if (errorLower.includes("timeout")) {
+    suggestions.push("Operation timed out - the element may not be visible or page is still loading");
+    suggestions.push("Consider adding a wait step before this action");
+    suggestions.push("Check if the page has fully loaded or if there are async operations");
+  }
+
+  if (step.type === "check" || errorLower.includes("check") || errorLower.includes("expected")) {
+    suggestions.push(`Check failed for: "${step.instruction}"`);
+    suggestions.push("Verify the expected condition matches the current page state");
+    suggestions.push("Consider rewording the check or using a different assertion");
+  }
+
+  if (suggestions.length === 0) {
+    suggestions.push(`Step failed: "${step.instruction}"`);
+    suggestions.push(`Error: ${error.message}`);
+    suggestions.push("Review the page state and try a different approach");
+  }
+
+  return suggestions;
+}
+
+/**
+ * Main class for parsing and executing behavior specifications against a running application.
+ *
+ * Snapshot Lifecycle Management
+ * -----------------------------
+ * This runner manages B-Test's snapshot lifecycle to ensure correct diff-based assertions:
+ *
+ * 1. Before first step: Take initial snapshot (establishes first "before" baseline)
+ * 2. Before each Act step: Reset snapshots + take new snapshot (fresh "before" baseline)
+ * 3. Execute Act step: Page state changes
+ * 4. Check step: executeSemanticCheck takes "after" snapshot, then asserts diff
+ *
+ * This ensures that semantic checks always compare "state before action" vs "state at check time".
+ */
+export class SpecTestRunner {
+  private config: SpecTestConfig;
+  private stagehand: Stagehand | null = null;
+  private tester: Tester | null = null;
+
+  constructor(config: SpecTestConfig) {
+    this.config = config;
+  }
+
+  /**
+   * Initialize Stagehand browser and B-Test tester.
+   */
+  private async initialize(): Promise<{ stagehand: Stagehand; tester: Tester }> {
+    if (this.stagehand && this.tester) {
+      return { stagehand: this.stagehand, tester: this.tester };
+    }
+
+    // Dynamic import to avoid loading Stagehand at module level
+    const { Stagehand } = await import("@browserbasehq/stagehand");
+    const { Tester } = await import("@/lib/b-test");
+
+    const isLocal = !this.config.browserbaseApiKey;
+
+    this.stagehand = new Stagehand({
+      env: isLocal ? "LOCAL" : "BROWSERBASE",
+      apiKey: this.config.browserbaseApiKey,
+      localBrowserLaunchOptions: isLocal
+        ? { headless: this.config.headless ?? true }
+        : undefined,
+      ...this.config.stagehandOptions,
+    });
+
+    await this.stagehand.init();
+    const page = this.stagehand.context.activePage();
+
+    if (!page) {
+      throw new Error("Failed to get active page from Stagehand");
+    }
+
+    // Tester accepts both Playwright and Stagehand pages via GenericPage interface
+    // Only pass aiModel if defined, otherwise let Tester use its default
+    this.tester = this.config.aiModel
+      ? new Tester(page, this.config.aiModel)
+      : new Tester(page);
+
+    return { stagehand: this.stagehand, tester: this.tester };
+  }
+
+  /**
+   * Run a specification from a markdown file.
+   *
+   * @param filePath - Path to markdown spec file
+   * @param exampleName - Optional example name to run (runs all if not specified)
+   */
+  async runFromFile(filePath: string, exampleName?: string): Promise<SpecTestResult> {
+    const spec = await parseSpecFile(filePath);
+    return this.runFromSpec(spec, exampleName);
+  }
+
+  /**
+   * Run a parsed specification.
+   *
+   * Runs all examples or a specific example by name.
+   *
+   * @param spec - Parsed TestableSpec
+   * @param exampleName - Optional example name to run (runs all if not specified)
+   */
+  async runFromSpec(spec: TestableSpec, exampleName?: string): Promise<SpecTestResult> {
+    const startTime = Date.now();
+
+    // Filter examples to run
+    const examplesToRun = exampleName
+      ? spec.examples.filter(e => e.name === exampleName)
+      : spec.examples;
+
+    if (examplesToRun.length === 0) {
+      const availableNames = spec.examples.map(e => e.name).join(", ");
+      throw new Error(
+        exampleName
+          ? `Example "${exampleName}" not found. Available: ${availableNames}`
+          : "No examples found in specification"
+      );
+    }
+
+    const exampleResults: ExampleResult[] = [];
+
+    for (const example of examplesToRun) {
+      const result = await this.runExample(example);
+      exampleResults.push(result);
+    }
+
+    const duration = Date.now() - startTime;
+    const success = exampleResults.every(r => r.success);
+
+    // For backwards compatibility, expose first example's results at top level
+    const firstResult = exampleResults[0];
+
+    return {
+      success,
+      spec,
+      exampleResults,
+      duration,
+      // Deprecated fields for backwards compatibility
+      steps: firstResult?.steps ?? [],
+      failedAt: firstResult?.failedAt,
+    };
+  }
+
+  /**
+   * Run a single example.
+   *
+   * Manages the snapshot lifecycle for correct diff-based semantic assertions:
+   * - Initial snapshot before any steps
+   * - Reset + snapshot before each Act (new baseline)
+   * - Check steps take "after" snapshot and assert
+   */
+  async runExample(example: SpecExample): Promise<ExampleResult> {
+    const startTime = Date.now();
+    const { stagehand, tester } = await this.initialize();
+    const stagehandPage = stagehand.context.activePage();
+
+    if (!stagehandPage) {
+      throw new Error("No active page available");
+    }
+
+    // Cast Stagehand's Page to Playwright's Page for type compatibility
+    const page = stagehandPage as unknown as Page;
+
+    // Navigate to base URL (fresh start for each example)
+    await page.goto(this.config.baseUrl);
+
+    // Take initial snapshot - establishes first "before" baseline
+    await tester.snapshot(page);
+
+    const stepResults: StepResult[] = [];
+    let failedAt: ExampleResult["failedAt"] | undefined;
+
+    for (let i = 0; i < example.steps.length; i++) {
+      const step = example.steps[i];
+      const context: StepContext = {
+        stepIndex: i,
+        totalSteps: example.steps.length,
+        previousResults: stepResults,
+        page,
+        stagehand,
+        tester,
+      };
+
+      const stepResult = await this.runStep(step, context);
+      stepResults.push(stepResult);
+
+      if (!stepResult.success) {
+        const error = new Error(
+          step.type === "act"
+            ? stepResult.actResult?.error ?? "Act step failed"
+            : stepResult.checkResult?.actual ?? "Check step failed"
+        );
+        const failureContext = await generateFailureContext(page, step, error);
+
+        failedAt = {
+          stepIndex: i,
+          step,
+          context: failureContext,
+        };
+        break;
+      }
+    }
+
+    const duration = Date.now() - startTime;
+
+    return {
+      example,
+      success: !failedAt,
+      steps: stepResults,
+      duration,
+      failedAt,
+    };
+  }
+
+  /**
+   * Execute a single step with context.
+   *
+   * For Act steps: Resets snapshots and takes a fresh "before" baseline,
+   * then executes the action.
+   *
+   * For Check steps: Delegates to executeCheckStep which takes the "after"
+   * snapshot and performs the assertion.
+   */
+  async runStep(step: SpecStep, context: StepContext): Promise<StepResult> {
+    const { page, stagehand, tester } = context;
+    const stepStart = Date.now();
+
+    if (step.type === "act") {
+      // Before executing Act: reset snapshots and take fresh "before" baseline
+      // This ensures the upcoming Check steps compare against pre-action state
+      tester.clearSnapshots();
+      await tester.snapshot(page);
+
+      const actResult = await executeActStep(step.instruction, stagehand);
+      const duration = Date.now() - stepStart;
+
+      return {
+        step,
+        success: actResult.success,
+        duration,
+        actResult,
+      };
+    }
+
+    // Check step: executeCheckStep will take "after" snapshot and assert
+    const checkType = step.checkType ?? "semantic";
+    const checkResult = await executeCheckStep(
+      step.instruction,
+      checkType,
+      page,
+      tester
+    );
+    const duration = Date.now() - stepStart;
+
+    return {
+      step,
+      success: checkResult.passed,
+      duration,
+      checkResult,
+    };
+  }
+
+  /**
+   * Close browser and clean up resources.
+   */
+  async close(): Promise<void> {
+    if (this.stagehand) {
+      await this.stagehand.close();
+      this.stagehand = null;
+    }
+    if (this.tester) {
+      this.tester.clearSnapshots();
+      this.tester = null;
+    }
+  }
+}

--- a/lib/spec-test/tests/fixtures/dashboard-page.html
+++ b/lib/spec-test/tests/fixtures/dashboard-page.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dashboard - Test App</title>
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      max-width: 800px;
+      margin: 50px auto;
+      padding: 20px;
+    }
+    .welcome-message {
+      color: #008800;
+      padding: 15px;
+      background: #eeffee;
+      border-radius: 4px;
+      margin-bottom: 20px;
+      font-size: 18px;
+    }
+    h1 {
+      margin-bottom: 20px;
+    }
+    .dashboard-content {
+      padding: 20px;
+      background: #f5f5f5;
+      border-radius: 4px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Dashboard</h1>
+
+  <div class="welcome-message">
+    Welcome back, user@example.com!
+  </div>
+
+  <div class="dashboard-content">
+    <p>This is your dashboard. You are now logged in.</p>
+  </div>
+</body>
+</html>

--- a/lib/spec-test/tests/fixtures/login-failure-spec.md
+++ b/lib/spec-test/tests/fixtures/login-failure-spec.md
@@ -1,0 +1,13 @@
+# Login Failure
+
+Test that clicking a non-existent element generates proper failure context.
+
+Directory: `app/(app)/auth/behaviors/login/`
+
+## Examples
+
+### Click non-existent element
+
+#### Steps
+* Act: User clicks the Submit Application button
+* Check: Error message is displayed

--- a/lib/spec-test/tests/fixtures/login-page.html
+++ b/lib/spec-test/tests/fixtures/login-page.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Login - Test App</title>
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      max-width: 400px;
+      margin: 50px auto;
+      padding: 20px;
+    }
+    .form-group {
+      margin-bottom: 15px;
+    }
+    label {
+      display: block;
+      margin-bottom: 5px;
+      font-weight: 500;
+    }
+    input {
+      width: 100%;
+      padding: 10px;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      box-sizing: border-box;
+    }
+    button {
+      width: 100%;
+      padding: 12px;
+      background: #0066cc;
+      color: white;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 16px;
+    }
+    button:hover {
+      background: #0052a3;
+    }
+    .error-message {
+      color: #cc0000;
+      padding: 10px;
+      background: #ffeeee;
+      border-radius: 4px;
+      margin-bottom: 15px;
+      display: none;
+    }
+    .success-message {
+      color: #008800;
+      padding: 10px;
+      background: #eeffee;
+      border-radius: 4px;
+      margin-bottom: 15px;
+      display: none;
+    }
+    h1 {
+      margin-bottom: 20px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Login</h1>
+
+  <div id="error-message" class="error-message"></div>
+  <div id="success-message" class="success-message"></div>
+
+  <form id="login-form">
+    <div class="form-group">
+      <label for="email">Email</label>
+      <input type="email" id="email" name="email" placeholder="Enter your email" required>
+    </div>
+
+    <div class="form-group">
+      <label for="password">Password</label>
+      <input type="password" id="password" name="password" placeholder="Enter your password" required>
+    </div>
+
+    <button type="submit">Login</button>
+  </form>
+
+  <script>
+    const form = document.getElementById('login-form');
+    const errorMessage = document.getElementById('error-message');
+    const successMessage = document.getElementById('success-message');
+
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+
+      const email = document.getElementById('email').value;
+      const password = document.getElementById('password').value;
+
+      // Hide previous messages
+      errorMessage.style.display = 'none';
+      successMessage.style.display = 'none';
+
+      // Simple validation
+      if (email === 'user@example.com' && password === 'password123') {
+        // Success - redirect to dashboard immediately
+        window.location.href = '/dashboard';
+      } else {
+        // Error
+        errorMessage.textContent = 'Invalid email or password';
+        errorMessage.style.display = 'block';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/lib/spec-test/tests/fixtures/login-spec.md
+++ b/lib/spec-test/tests/fixtures/login-spec.md
@@ -1,0 +1,16 @@
+# Login
+
+Test the login behavior with valid credentials.
+
+Directory: `app/(app)/auth/behaviors/login/`
+
+## Examples
+
+### Login with valid credentials
+
+#### Steps
+* Act: User enters "user@example.com" in email field
+* Act: User enters "password123" in password field
+* Act: User clicks Login button
+* Check: URL contains /dashboard
+* Check: Page title contains Dashboard

--- a/lib/spec-test/tests/fixtures/sample-spec.md
+++ b/lib/spec-test/tests/fixtures/sample-spec.md
@@ -2,7 +2,11 @@
 
 A user can log into the application with their email and password.
 
-## Steps
+## Examples
+
+### Login with valid credentials
+
+#### Steps
 * Act: User navigates to /login
 * Act: User enters "user@example.com" in email field
 * Act: User enters "password123" in password field

--- a/lib/spec-test/tests/fixtures/sample-spec.md
+++ b/lib/spec-test/tests/fixtures/sample-spec.md
@@ -1,0 +1,11 @@
+# Login
+
+A user can log into the application with their email and password.
+
+## Steps
+* Act: User navigates to /login
+* Act: User enters "user@example.com" in email field
+* Act: User enters "password123" in password field
+* Act: User clicks Login button
+* Check: URL contains /dashboard
+* Check: Welcome message is displayed

--- a/lib/spec-test/tests/integration.test.ts
+++ b/lib/spec-test/tests/integration.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Integration tests for spec-test library.
+ *
+ * These tests validate the full flow: Spec → Stagehand Act → B-Test Check → Pass/Fail
+ * using a real browser against test HTML pages.
+ *
+ * Note: These tests require:
+ * - Chromium/Chrome installed (Stagehand will use it)
+ * - OPENAI_API_KEY for semantic checks
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { SpecTestRunner, parseSpecFile } from "../index";
+import { Server } from "bun";
+import path from "path";
+import { readFileSync } from "fs";
+
+const FIXTURES_DIR = path.join(__dirname, "fixtures");
+const TEST_PORT = 9876;
+const BASE_URL = `http://localhost:${TEST_PORT}`;
+
+// Simple static file server for test fixtures
+function createTestServer(): Server {
+  return Bun.serve({
+    port: TEST_PORT,
+    fetch(req) {
+      const url = new URL(req.url);
+      let filePath: string;
+
+      // Route handling
+      if (url.pathname === "/" || url.pathname === "/login") {
+        filePath = path.join(FIXTURES_DIR, "login-page.html");
+      } else if (url.pathname === "/dashboard") {
+        filePath = path.join(FIXTURES_DIR, "dashboard-page.html");
+      } else {
+        return new Response("Not Found", { status: 404 });
+      }
+
+      try {
+        const content = readFileSync(filePath, "utf-8");
+        return new Response(content, {
+          headers: { "Content-Type": "text/html" },
+        });
+      } catch {
+        return new Response("Not Found", { status: 404 });
+      }
+    },
+  });
+}
+
+describe("SpecTestRunner Integration", () => {
+  let server: Server;
+  let runner: SpecTestRunner;
+
+  beforeAll(() => {
+    server = createTestServer();
+    runner = new SpecTestRunner({
+      baseUrl: `${BASE_URL}/login`,
+      headless: true,
+    });
+  });
+
+  afterAll(async () => {
+    await runner.close();
+    server.stop();
+  });
+
+  describe("parseSpecFile", () => {
+    it("should parse login spec file correctly", async () => {
+      const specPath = path.join(FIXTURES_DIR, "login-spec.md");
+      const spec = await parseSpecFile(specPath);
+
+      expect(spec.name).toBe("Login");
+      expect(spec.directory).toBe("app/(app)/auth/behaviors/login/");
+      expect(spec.examples).toHaveLength(1);
+
+      const example = spec.examples[0];
+      expect(example.name).toBe("Login with valid credentials");
+      expect(example.steps).toHaveLength(5);
+      expect(example.steps[0].type).toBe("act");
+      expect(example.steps[3].type).toBe("check");
+      expect(example.steps[3].checkType).toBe("deterministic"); // URL contains
+      expect(example.steps[4].checkType).toBe("deterministic"); // Page title contains
+    });
+
+    it("should parse failure spec file correctly", async () => {
+      const specPath = path.join(FIXTURES_DIR, "login-failure-spec.md");
+      const spec = await parseSpecFile(specPath);
+
+      expect(spec.name).toBe("Login Failure");
+      expect(spec.examples).toHaveLength(1);
+
+      const example = spec.examples[0];
+      expect(example.name).toBe("Click non-existent element");
+      expect(example.steps).toHaveLength(2);
+      expect(example.steps[0].type).toBe("act");
+      expect(example.steps[0].instruction).toContain("Submit Application");
+    });
+  });
+
+  // Note: These tests require a real browser and OPENAI_API_KEY for semantic checks.
+
+  describe("Full E2E flow (requires browser)", () => {
+    it("should successfully run login spec with valid credentials", async () => {
+      const specPath = path.join(FIXTURES_DIR, "login-spec.md");
+      const result = await runner.runFromFile(specPath);
+
+      expect(result.success).toBe(true);
+      expect(result.exampleResults).toHaveLength(1);
+
+      const exampleResult = result.exampleResults[0];
+      expect(exampleResult.example.name).toBe("Login with valid credentials");
+      expect(exampleResult.success).toBe(true);
+      expect(exampleResult.steps).toHaveLength(5);
+      expect(exampleResult.steps.every(s => s.success)).toBe(true);
+      expect(exampleResult.failedAt).toBeUndefined();
+    }, 60000); // 60s timeout for browser operations
+
+    it("should generate failure context when action fails", async () => {
+      const specPath = path.join(FIXTURES_DIR, "login-failure-spec.md");
+      const result = await runner.runFromFile(specPath);
+
+      expect(result.success).toBe(false);
+      expect(result.exampleResults).toHaveLength(1);
+
+      const exampleResult = result.exampleResults[0];
+      expect(exampleResult.failedAt).toBeDefined();
+      expect(exampleResult.failedAt?.stepIndex).toBe(0);
+      expect(exampleResult.failedAt?.context).toBeDefined();
+      expect(exampleResult.failedAt?.context.suggestions.length).toBeGreaterThan(0);
+      expect(exampleResult.failedAt?.context.availableElements.length).toBeGreaterThan(0);
+    }, 60000);
+
+    it("should report correct step results", async () => {
+      const specPath = path.join(FIXTURES_DIR, "login-spec.md");
+      const result = await runner.runFromFile(specPath);
+
+      const exampleResult = result.exampleResults[0];
+
+      // Check Act results
+      const actSteps = exampleResult.steps.filter(s => s.step.type === "act");
+      actSteps.forEach(step => {
+        expect(step.actResult).toBeDefined();
+        expect(step.actResult?.success).toBe(true);
+        expect(step.duration).toBeGreaterThan(0);
+      });
+
+      // Check Check results
+      const checkSteps = exampleResult.steps.filter(s => s.step.type === "check");
+      checkSteps.forEach(step => {
+        expect(step.checkResult).toBeDefined();
+        expect(step.checkResult?.passed).toBe(true);
+      });
+    }, 60000);
+
+    it("should run specific example by name", async () => {
+      const specPath = path.join(FIXTURES_DIR, "login-spec.md");
+      const result = await runner.runFromFile(specPath, "Login with valid credentials");
+
+      expect(result.success).toBe(true);
+      expect(result.exampleResults).toHaveLength(1);
+      expect(result.exampleResults[0].example.name).toBe("Login with valid credentials");
+    }, 60000);
+  });
+});
+
+/**
+ * Manual test runner for integration tests.
+ * Run this directly with: bun lib/spec-test/tests/integration.test.ts --run
+ */
+if (process.argv.includes("--run")) {
+  (async () => {
+    console.log("Starting integration test server...");
+    const server = createTestServer();
+    console.log(`Server running at ${BASE_URL}`);
+
+    const runner = new SpecTestRunner({
+      baseUrl: `${BASE_URL}/login`,
+      headless: false, // Show browser for debugging
+    });
+
+    try {
+      console.log("\n--- Running login spec ---");
+      const specPath = path.join(FIXTURES_DIR, "login-spec.md");
+      const result = await runner.runFromFile(specPath);
+
+      console.log(`\nResult: ${result.success ? "PASSED" : "FAILED"}`);
+      console.log(`Duration: ${result.duration}ms`);
+      console.log(`Examples: ${result.exampleResults.length}`);
+
+      result.exampleResults.forEach((exampleResult) => {
+        const exampleStatus = exampleResult.success ? "PASSED" : "FAILED";
+        console.log(`\n  Example: ${exampleResult.example.name} - ${exampleStatus}`);
+        console.log(`  Duration: ${exampleResult.duration}ms`);
+
+        exampleResult.steps.forEach((step, i) => {
+          const status = step.success ? "+" : "x";
+          console.log(`    ${status} Step ${i + 1}: ${step.step.instruction}`);
+        });
+
+        if (exampleResult.failedAt) {
+          console.log(`\n  Failed at step ${exampleResult.failedAt.stepIndex + 1}:`);
+          console.log(`    Error: ${exampleResult.failedAt.context.error}`);
+          console.log("    Suggestions:");
+          exampleResult.failedAt.context.suggestions.forEach(s => console.log(`      - ${s}`));
+        }
+      });
+    } catch (error) {
+      console.error("Test error:", error);
+    } finally {
+      await runner.close();
+      server.stop();
+    }
+  })();
+}

--- a/lib/spec-test/tests/run-spec.ts
+++ b/lib/spec-test/tests/run-spec.ts
@@ -1,0 +1,140 @@
+/**
+ * Manual Spec Test Runner
+ *
+ * Run this script to test the spec-test library against a real running application.
+ *
+ * Usage:
+ *   bun lib/spec-test/tests/run-spec.ts [spec-file] [example-name]
+ *
+ * Examples:
+ *   bun lib/spec-test/tests/run-spec.ts                                          # Run sample spec
+ *   bun lib/spec-test/tests/run-spec.ts docs/specs/login.md                      # Run all examples
+ *   bun lib/spec-test/tests/run-spec.ts docs/specs/login.md "Login with email"   # Run specific example
+ *
+ * Requirements:
+ *   - App running on http://localhost:8080 (or set BASE_URL env)
+ *   - OPENAI_API_KEY set for semantic checks
+ */
+
+import { SpecTestRunner, parseSpecFile } from "../index";
+import path from "path";
+
+const BASE_URL = process.env.BASE_URL ?? "http://localhost:8080";
+const SPEC_FILE = process.argv[2] ?? path.join(__dirname, "fixtures", "login-spec.md");
+const EXAMPLE_NAME = process.argv[3]; // Optional: run specific example
+
+async function main() {
+  console.log("=".repeat(60));
+  console.log("Spec Test Runner");
+  console.log("=".repeat(60));
+  console.log(`Base URL: ${BASE_URL}`);
+  console.log(`Spec file: ${SPEC_FILE}`);
+  if (EXAMPLE_NAME) {
+    console.log(`Example: ${EXAMPLE_NAME}`);
+  }
+  console.log();
+
+  // Parse the spec file first to show what we're testing
+  const spec = await parseSpecFile(SPEC_FILE);
+  console.log(`Behavior: ${spec.name}`);
+  if (spec.directory) {
+    console.log(`Directory: ${spec.directory}`);
+  }
+  console.log(`Examples: ${spec.examples.length}`);
+  console.log();
+
+  // Show all examples and their steps
+  spec.examples.forEach((example, exampleIndex) => {
+    const willRun = !EXAMPLE_NAME || example.name === EXAMPLE_NAME;
+    const marker = willRun ? ">>>" : "   ";
+    console.log(`${marker} Example ${exampleIndex + 1}: ${example.name}`);
+
+    example.steps.forEach((step, i) => {
+      const prefix = step.type === "act" ? "->" : "ok";
+      const checkType = step.checkType ? ` [${step.checkType}]` : "";
+      console.log(`      ${i + 1}. ${prefix} ${step.type.toUpperCase()}: ${step.instruction}${checkType}`);
+    });
+    console.log();
+  });
+
+  // Create runner
+  const runner = new SpecTestRunner({
+    baseUrl: BASE_URL,
+    headless: false, // Show browser for debugging
+  });
+
+  try {
+    console.log("Starting browser...");
+    const result = await runner.runFromSpec(spec, EXAMPLE_NAME);
+
+    console.log();
+    console.log("=".repeat(60));
+    console.log(result.success ? "PASSED" : "FAILED");
+    console.log("=".repeat(60));
+    console.log(`Total Duration: ${result.duration}ms`);
+    console.log(`Examples Run: ${result.exampleResults.length}`);
+    console.log();
+
+    // Show results for each example
+    result.exampleResults.forEach((exampleResult, exampleIndex) => {
+      const status = exampleResult.success ? "[PASS]" : "[FAIL]";
+      console.log(`${status} Example ${exampleIndex + 1}: ${exampleResult.example.name}`);
+      console.log(`  Duration: ${exampleResult.duration}ms`);
+
+      // Show step results
+      exampleResult.steps.forEach((stepResult, i) => {
+        const stepStatus = stepResult.success ? "+" : "x";
+        const type = stepResult.step.type.toUpperCase();
+        console.log(`  ${stepStatus} Step ${i + 1} (${type}): ${stepResult.step.instruction}`);
+
+        if (stepResult.actResult && !stepResult.actResult.success) {
+          console.log(`    Error: ${stepResult.actResult.error}`);
+        }
+        if (stepResult.checkResult && !stepResult.checkResult.passed) {
+          console.log(`    Expected: ${stepResult.checkResult.expected}`);
+          console.log(`    Actual: ${stepResult.checkResult.actual}`);
+          if (stepResult.checkResult.reasoning) {
+            console.log(`    Reasoning: ${stepResult.checkResult.reasoning}`);
+          }
+        }
+      });
+
+      // Show failure context if failed
+      if (exampleResult.failedAt) {
+        console.log();
+        console.log("  Failure Context:");
+        console.log(`    Step: ${exampleResult.failedAt.stepIndex + 1}`);
+        console.log(`    URL: ${exampleResult.failedAt.context.pageUrl}`);
+        console.log(`    Error: ${exampleResult.failedAt.context.error}`);
+        console.log();
+        console.log("    Suggestions:");
+        exampleResult.failedAt.context.suggestions.forEach(s => {
+          console.log(`      - ${s}`);
+        });
+        console.log();
+        console.log("    Available Elements:");
+        exampleResult.failedAt.context.availableElements.slice(0, 10).forEach(el => {
+          console.log(`      - ${el.type}: ${el.text || el.selector}`);
+        });
+      }
+
+      console.log();
+    });
+
+    // Summary
+    const passed = result.exampleResults.filter(r => r.success).length;
+    const failed = result.exampleResults.filter(r => !r.success).length;
+    console.log("=".repeat(60));
+    console.log(`Summary: ${passed} passed, ${failed} failed`);
+    console.log("=".repeat(60));
+
+    process.exit(result.success ? 0 : 1);
+  } catch (error) {
+    console.error("Runner error:", error);
+    process.exit(1);
+  } finally {
+    await runner.close();
+  }
+}
+
+main();

--- a/lib/spec-test/tests/spec-test.test.ts
+++ b/lib/spec-test/tests/spec-test.test.ts
@@ -1,0 +1,446 @@
+import { describe, it, expect, vi } from "vitest";
+import { parseSteps, parseSpecFile, classifyCheck, executeActStep, executeCheckStep, generateFailureContext } from "../index";
+import path from "path";
+import type { Stagehand } from "@browserbasehq/stagehand";
+import type { Page } from "playwright";
+import type { Tester } from "@/lib/b-test";
+import type { SpecStep } from "../types";
+
+describe("parseSteps", () => {
+  it("should parse Act steps from markdown content", () => {
+    const content = `
+#### Steps
+* Act: User navigates to /login
+* Act: User clicks Login button
+`;
+    const steps = parseSteps(content);
+
+    expect(steps).toHaveLength(2);
+    expect(steps[0]).toEqual({
+      type: "act",
+      instruction: "User navigates to /login",
+      lineNumber: expect.any(Number),
+    });
+    expect(steps[1]).toEqual({
+      type: "act",
+      instruction: "User clicks Login button",
+      lineNumber: expect.any(Number),
+    });
+  });
+
+  it("should parse Check steps with deterministic classification", () => {
+    const content = `
+#### Steps
+* Check: URL contains /dashboard
+* Check: Page title is 'Home'
+`;
+    const steps = parseSteps(content);
+
+    expect(steps).toHaveLength(2);
+    expect(steps[0]).toEqual({
+      type: "check",
+      instruction: "URL contains /dashboard",
+      checkType: "deterministic",
+      lineNumber: expect.any(Number),
+    });
+    expect(steps[1]).toEqual({
+      type: "check",
+      instruction: "Page title is 'Home'",
+      checkType: "deterministic",
+      lineNumber: expect.any(Number),
+    });
+  });
+
+  it("should parse Check steps with semantic classification", () => {
+    const content = `
+#### Steps
+* Check: Error message is displayed
+* Check: Welcome message is displayed
+`;
+    const steps = parseSteps(content);
+
+    expect(steps).toHaveLength(2);
+    expect(steps[0]).toEqual({
+      type: "check",
+      instruction: "Error message is displayed",
+      checkType: "semantic",
+      lineNumber: expect.any(Number),
+    });
+    expect(steps[1]).toEqual({
+      type: "check",
+      instruction: "Welcome message is displayed",
+      checkType: "semantic",
+      lineNumber: expect.any(Number),
+    });
+  });
+
+  it("should parse mixed Act and Check steps", () => {
+    const content = `
+#### Steps
+* Act: User logs in as "client"
+* Act: User navigates to the projects page
+* Check: Projects list is visible
+* Act: User clicks Create Project button
+* Check: URL contains /projects/new
+`;
+    const steps = parseSteps(content);
+
+    expect(steps).toHaveLength(5);
+    expect(steps[0].type).toBe("act");
+    expect(steps[1].type).toBe("act");
+    expect(steps[2].type).toBe("check");
+    expect(steps[2].checkType).toBe("semantic");
+    expect(steps[3].type).toBe("act");
+    expect(steps[4].type).toBe("check");
+    expect(steps[4].checkType).toBe("deterministic");
+  });
+});
+
+describe("classifyCheck", () => {
+  it('should classify "URL contains" as deterministic', () => {
+    expect(classifyCheck("URL contains /projects")).toBe("deterministic");
+    expect(classifyCheck("URL contains /dashboard")).toBe("deterministic");
+  });
+
+  it('should classify "Page title is" as deterministic', () => {
+    expect(classifyCheck("Page title is 'Projects'")).toBe("deterministic");
+    expect(classifyCheck("Page title is 'Home'")).toBe("deterministic");
+  });
+
+  it('should classify "URL is" as deterministic', () => {
+    expect(classifyCheck("URL is http://localhost:8080/login")).toBe(
+      "deterministic"
+    );
+  });
+
+  it('should classify "Page title contains" as deterministic', () => {
+    expect(classifyCheck("Page title contains 'Dashboard'")).toBe(
+      "deterministic"
+    );
+  });
+
+  it('should classify "Element count is" as deterministic', () => {
+    expect(classifyCheck("Element count is 5")).toBe("deterministic");
+  });
+
+  it('should classify "Input value is" as deterministic', () => {
+    expect(classifyCheck("Input value is 'test@example.com'")).toBe(
+      "deterministic"
+    );
+  });
+
+  it('should classify "Checkbox is checked" as deterministic', () => {
+    expect(classifyCheck("Checkbox is checked")).toBe("deterministic");
+  });
+
+  it('should classify "Error message is displayed" as semantic', () => {
+    expect(classifyCheck("Error message is displayed")).toBe("semantic");
+  });
+
+  it('should classify "Success notification appears" as semantic', () => {
+    expect(classifyCheck("Success notification appears")).toBe("semantic");
+  });
+
+  it('should classify "New project appears in the list" as semantic', () => {
+    expect(classifyCheck("New project appears in the list")).toBe("semantic");
+  });
+
+  it('should classify "Form validation errors are shown" as semantic', () => {
+    expect(classifyCheck("Form validation errors are shown")).toBe("semantic");
+  });
+});
+
+describe("parseSpecFile", () => {
+  it("should parse spec file and extract name from heading", async () => {
+    const fixturePath = path.join(__dirname, "fixtures", "sample-spec.md");
+    const spec = await parseSpecFile(fixturePath);
+
+    expect(spec.name).toBe("Login");
+  });
+
+  it("should parse spec file and extract steps", async () => {
+    const fixturePath = path.join(__dirname, "fixtures", "sample-spec.md");
+    const spec = await parseSpecFile(fixturePath);
+
+    expect(spec.steps).toHaveLength(6);
+    expect(spec.steps[0]).toEqual({
+      type: "act",
+      instruction: "User navigates to /login",
+      lineNumber: expect.any(Number),
+    });
+    expect(spec.steps[4]).toEqual({
+      type: "check",
+      instruction: "URL contains /dashboard",
+      checkType: "deterministic",
+      lineNumber: expect.any(Number),
+    });
+    expect(spec.steps[5]).toEqual({
+      type: "check",
+      instruction: "Welcome message is displayed",
+      checkType: "semantic",
+      lineNumber: expect.any(Number),
+    });
+  });
+});
+
+describe("executeActStep", () => {
+  it("should return success with page URL when action succeeds", async () => {
+    const mockPage = {
+      url: vi.fn().mockReturnValue("http://localhost:8080/dashboard"),
+    };
+    const mockStagehand = {
+      act: vi.fn().mockResolvedValue(undefined),
+      context: {
+        activePage: vi.fn().mockReturnValue(mockPage),
+      },
+    } as unknown as Stagehand;
+
+    const result = await executeActStep("User clicks Login button", mockStagehand);
+
+    expect(result.success).toBe(true);
+    expect(result.pageUrl).toBe("http://localhost:8080/dashboard");
+    expect(result.duration).toBeGreaterThanOrEqual(0);
+    expect(mockStagehand.act).toHaveBeenCalledWith("User clicks Login button");
+  });
+
+  it("should return failure with error when action fails", async () => {
+    const mockPage = {
+      url: vi.fn().mockReturnValue("http://localhost:8080/login"),
+      evaluate: vi.fn().mockResolvedValue("<html><body>Login page</body></html>"),
+    };
+    const mockStagehand = {
+      act: vi.fn().mockRejectedValue(new Error("Element not found")),
+      context: {
+        activePage: vi.fn().mockReturnValue(mockPage),
+      },
+      observe: vi.fn().mockResolvedValue([
+        { description: "Click Sign Up button" },
+        { description: "Enter text in email field" },
+      ]),
+    } as unknown as Stagehand;
+
+    const result = await executeActStep("User clicks non-existent button", mockStagehand);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Element not found");
+    expect(result.pageSnapshot).toBe("<html><body>Login page</body></html>");
+    expect(result.availableActions).toEqual([
+      "Click Sign Up button",
+      "Enter text in email field",
+    ]);
+    expect(result.duration).toBeGreaterThanOrEqual(0);
+  });
+
+  it("should measure duration correctly", async () => {
+    const mockPage = {
+      url: vi.fn().mockReturnValue("http://localhost:8080/dashboard"),
+    };
+    const mockStagehand = {
+      act: vi.fn().mockImplementation(() => new Promise(resolve => setTimeout(resolve, 50))),
+      context: {
+        activePage: vi.fn().mockReturnValue(mockPage),
+      },
+    } as unknown as Stagehand;
+
+    const result = await executeActStep("User waits", mockStagehand);
+
+    expect(result.duration).toBeGreaterThanOrEqual(50);
+  });
+});
+
+describe("executeCheckStep", () => {
+  it("should pass deterministic URL contains check", async () => {
+    const mockPage = {
+      url: vi.fn().mockReturnValue("http://localhost:8080/dashboard"),
+    } as unknown as Page;
+    const mockTester = {} as Tester;
+
+    const result = await executeCheckStep("URL contains /dashboard", "deterministic", mockPage, mockTester);
+
+    expect(result.passed).toBe(true);
+    expect(result.checkType).toBe("deterministic");
+    expect(result.expected).toBe("/dashboard");
+    expect(result.actual).toBe("http://localhost:8080/dashboard");
+  });
+
+  it("should fail deterministic URL contains check when not matching", async () => {
+    const mockPage = {
+      url: vi.fn().mockReturnValue("http://localhost:8080/login"),
+    } as unknown as Page;
+    const mockTester = {} as Tester;
+
+    const result = await executeCheckStep("URL contains /dashboard", "deterministic", mockPage, mockTester);
+
+    expect(result.passed).toBe(false);
+    expect(result.checkType).toBe("deterministic");
+    expect(result.expected).toBe("/dashboard");
+    expect(result.actual).toBe("http://localhost:8080/login");
+  });
+
+  it("should pass deterministic URL is check", async () => {
+    const mockPage = {
+      url: vi.fn().mockReturnValue("http://localhost:8080/login"),
+    } as unknown as Page;
+    const mockTester = {} as Tester;
+
+    const result = await executeCheckStep("URL is http://localhost:8080/login", "deterministic", mockPage, mockTester);
+
+    expect(result.passed).toBe(true);
+    expect(result.checkType).toBe("deterministic");
+    expect(result.expected).toBe("http://localhost:8080/login");
+    expect(result.actual).toBe("http://localhost:8080/login");
+  });
+
+  it("should pass deterministic Page title is check", async () => {
+    const mockPage = {
+      url: vi.fn().mockReturnValue("http://localhost:8080"),
+      title: vi.fn().mockResolvedValue("Home Page"),
+    } as unknown as Page;
+    const mockTester = {} as Tester;
+
+    const result = await executeCheckStep("Page title is Home Page", "deterministic", mockPage, mockTester);
+
+    expect(result.passed).toBe(true);
+    expect(result.checkType).toBe("deterministic");
+    expect(result.expected).toBe("Home Page");
+    expect(result.actual).toBe("Home Page");
+  });
+
+  it("should pass deterministic Page title contains check", async () => {
+    const mockPage = {
+      url: vi.fn().mockReturnValue("http://localhost:8080"),
+      title: vi.fn().mockResolvedValue("My Dashboard - App"),
+    } as unknown as Page;
+    const mockTester = {} as Tester;
+
+    const result = await executeCheckStep("Page title contains Dashboard", "deterministic", mockPage, mockTester);
+
+    expect(result.passed).toBe(true);
+    expect(result.checkType).toBe("deterministic");
+    expect(result.expected).toBe("Dashboard");
+    expect(result.actual).toBe("My Dashboard - App");
+  });
+
+  it("should pass semantic check using tester.assert", async () => {
+    const mockPage = {
+      url: vi.fn().mockReturnValue("http://localhost:8080"),
+    } as unknown as Page;
+    const mockTester = {
+      snapshot: vi.fn().mockResolvedValue({ success: true, snapshotId: "snap1" }),
+      assert: vi.fn().mockResolvedValue(true),
+    } as unknown as Tester;
+
+    const result = await executeCheckStep("Error message is displayed", "semantic", mockPage, mockTester);
+
+    expect(result.passed).toBe(true);
+    expect(result.checkType).toBe("semantic");
+    expect(result.expected).toBe("Error message is displayed");
+    expect(mockTester.snapshot).toHaveBeenCalledWith(mockPage);
+    expect(mockTester.assert).toHaveBeenCalledWith("Error message is displayed");
+  });
+
+  it("should fail semantic check when tester.assert returns false", async () => {
+    const mockPage = {
+      url: vi.fn().mockReturnValue("http://localhost:8080"),
+    } as unknown as Page;
+    const mockTester = {
+      snapshot: vi.fn().mockResolvedValue({ success: true, snapshotId: "snap1" }),
+      assert: vi.fn().mockResolvedValue(false),
+    } as unknown as Tester;
+
+    const result = await executeCheckStep("Success notification appears", "semantic", mockPage, mockTester);
+
+    expect(result.passed).toBe(false);
+    expect(result.checkType).toBe("semantic");
+    expect(result.expected).toBe("Success notification appears");
+  });
+});
+
+describe("generateFailureContext", () => {
+  it("should capture page URL and snapshot", async () => {
+    const mockPage = {
+      url: vi.fn().mockReturnValue("http://localhost:8080/form"),
+      evaluate: vi.fn()
+        .mockResolvedValueOnce("<html><body>Test page</body></html>")
+        .mockResolvedValueOnce([]),
+    } as unknown as Page;
+    const step: SpecStep = { type: "act", instruction: "Click Submit button" };
+    const error = new Error("Element not found");
+
+    const context = await generateFailureContext(mockPage, step, error);
+
+    expect(context.pageUrl).toBe("http://localhost:8080/form");
+    expect(context.pageSnapshot).toBe("<html><body>Test page</body></html>");
+    expect(context.failedStep).toEqual(step);
+    expect(context.error).toBe("Element not found");
+  });
+
+  it("should extract interactive elements from page", async () => {
+    const mockElements = [
+      { type: "button", text: "Save", selector: "button#save" },
+      { type: "link", text: "Cancel", selector: "a.cancel" },
+      { type: "input", text: "", selector: "input[name='email']", attributes: { type: "email", name: "email" } },
+    ];
+    const mockPage = {
+      url: vi.fn().mockReturnValue("http://localhost:8080/form"),
+      evaluate: vi.fn()
+        .mockResolvedValueOnce("<html><body>Form</body></html>")
+        .mockResolvedValueOnce(mockElements),
+    } as unknown as Page;
+    const step: SpecStep = { type: "act", instruction: "Click Submit button" };
+    const error = new Error("Element not found");
+
+    const context = await generateFailureContext(mockPage, step, error);
+
+    expect(context.availableElements).toHaveLength(3);
+    expect(context.availableElements[0]).toEqual({ type: "button", text: "Save", selector: "button#save" });
+    expect(context.availableElements[1]).toEqual({ type: "link", text: "Cancel", selector: "a.cancel" });
+  });
+
+  it("should generate suggestions for 'not found' errors", async () => {
+    const mockPage = {
+      url: vi.fn().mockReturnValue("http://localhost:8080/form"),
+      evaluate: vi.fn()
+        .mockResolvedValueOnce("<html></html>")
+        .mockResolvedValueOnce([{ type: "button", text: "Save", selector: "button#save" }]),
+    } as unknown as Page;
+    const step: SpecStep = { type: "act", instruction: "Click Submit button" };
+    const error = new Error("Element not found");
+
+    const context = await generateFailureContext(mockPage, step, error);
+
+    expect(context.suggestions.length).toBeGreaterThan(0);
+    expect(context.suggestions.some(s => s.toLowerCase().includes("not found") || s.toLowerCase().includes("element"))).toBe(true);
+  });
+
+  it("should generate suggestions for timeout errors", async () => {
+    const mockPage = {
+      url: vi.fn().mockReturnValue("http://localhost:8080/form"),
+      evaluate: vi.fn()
+        .mockResolvedValueOnce("<html></html>")
+        .mockResolvedValueOnce([]),
+    } as unknown as Page;
+    const step: SpecStep = { type: "act", instruction: "Wait for modal" };
+    const error = new Error("Timeout waiting for element");
+
+    const context = await generateFailureContext(mockPage, step, error);
+
+    expect(context.suggestions.length).toBeGreaterThan(0);
+    expect(context.suggestions.some(s => s.toLowerCase().includes("timeout") || s.toLowerCase().includes("wait"))).toBe(true);
+  });
+
+  it("should generate suggestions for check failures", async () => {
+    const mockPage = {
+      url: vi.fn().mockReturnValue("http://localhost:8080/dashboard"),
+      evaluate: vi.fn()
+        .mockResolvedValueOnce("<html></html>")
+        .mockResolvedValueOnce([]),
+    } as unknown as Page;
+    const step: SpecStep = { type: "check", instruction: "URL contains /profile", checkType: "deterministic" };
+    const error = new Error("Check failed: expected /profile");
+
+    const context = await generateFailureContext(mockPage, step, error);
+
+    expect(context.suggestions.length).toBeGreaterThan(0);
+  });
+});

--- a/lib/spec-test/types.ts
+++ b/lib/spec-test/types.ts
@@ -1,0 +1,202 @@
+import type { Page } from "playwright";
+import type { Stagehand } from "@browserbasehq/stagehand";
+import type { Tester } from "@/lib/b-test";
+import type { LanguageModelV2 } from "@ai-sdk/provider";
+
+/**
+ * Configuration options for SpecTestRunner
+ */
+export interface SpecTestConfig {
+  /** Base URL of the application under test */
+  baseUrl: string;
+  /** Stagehand configuration options */
+  stagehandOptions?: Record<string, unknown>;
+  /** B-Test AI model override (e.g., openai("gpt-4o"), anthropic("claude-3-5-sonnet")) */
+  aiModel?: LanguageModelV2;
+  /** Browserbase API key for cloud execution (optional) */
+  browserbaseApiKey?: string;
+  /** Use headless browser (default: true) */
+  headless?: boolean;
+}
+
+/**
+ * A named example within a behavior specification
+ */
+export interface SpecExample {
+  /** Example name (e.g., "Execute login behavior") */
+  name: string;
+  /** Steps to execute for this example */
+  steps: SpecStep[];
+}
+
+/**
+ * Parsed behavior specification ready for execution.
+ *
+ * Epic Specification Format:
+ * - H1 = behavior name
+ * - `Directory:` = optional directory path
+ * - `## Examples` section contains named examples with `#### Steps`
+ */
+export interface TestableSpec {
+  /** Behavior name from specification (H1) */
+  name: string;
+  /** Directory where behavior is implemented (optional) */
+  directory?: string;
+  /** Named examples from the Examples section */
+  examples: SpecExample[];
+}
+
+/**
+ * A single step in a specification
+ */
+export interface SpecStep {
+  /** Step type: act for actions, check for verifications */
+  type: "act" | "check";
+  /** Natural language instruction */
+  instruction: string;
+  /** For checks: deterministic or semantic */
+  checkType?: "deterministic" | "semantic";
+  /** Original line number in spec file (for error reporting) */
+  lineNumber?: number;
+}
+
+/**
+ * Result of running a single example
+ */
+export interface ExampleResult {
+  /** Example that was executed */
+  example: SpecExample;
+  /** Overall success status */
+  success: boolean;
+  /** Results for each step */
+  steps: StepResult[];
+  /** Execution duration in ms */
+  duration: number;
+  /** Details about failure if success is false */
+  failedAt?: {
+    stepIndex: number;
+    step: SpecStep;
+    context: FailureContext;
+  };
+}
+
+/**
+ * Result of running a complete specification (all examples or specific one)
+ */
+export interface SpecTestResult {
+  /** Overall success status (true if all executed examples passed) */
+  success: boolean;
+  /** Spec that was executed */
+  spec: TestableSpec;
+  /** Results for each example that was run */
+  exampleResults: ExampleResult[];
+  /** Total execution duration in ms */
+  duration: number;
+  /**
+   * @deprecated Use exampleResults[n].steps instead
+   * Kept for backwards compatibility with single-example specs
+   */
+  steps: StepResult[];
+  /**
+   * @deprecated Use exampleResults[n].failedAt instead
+   * Kept for backwards compatibility with single-example specs
+   */
+  failedAt?: {
+    stepIndex: number;
+    step: SpecStep;
+    context: FailureContext;
+  };
+}
+
+/**
+ * Result of executing a single step
+ */
+export interface StepResult {
+  /** Step that was executed */
+  step: SpecStep;
+  /** Whether step succeeded */
+  success: boolean;
+  /** Execution duration in ms */
+  duration: number;
+  /** For act steps */
+  actResult?: ActResult;
+  /** For check steps */
+  checkResult?: CheckResult;
+}
+
+/**
+ * Result of executing an Act step
+ */
+export interface ActResult {
+  /** Whether action succeeded */
+  success: boolean;
+  /** Execution duration in ms */
+  duration: number;
+  /** Current page URL after action */
+  pageUrl?: string;
+  /** Error message if failed */
+  error?: string;
+  /** Page snapshot if failed (for debugging) */
+  pageSnapshot?: string;
+  /** Available actions on page if failed (for suggestions) */
+  availableActions?: string[];
+}
+
+/**
+ * Result of executing a Check step
+ */
+export interface CheckResult {
+  /** Whether check passed */
+  passed: boolean;
+  /** Type of check that was performed */
+  checkType: "deterministic" | "semantic";
+  /** Expected condition (from instruction) */
+  expected: string;
+  /** Actual value found */
+  actual: string;
+  /** LLM reasoning for semantic checks */
+  reasoning?: string;
+  /** Suggestion for fixing if failed */
+  suggestion?: string;
+}
+
+/**
+ * Rich context for debugging failures
+ */
+export interface FailureContext {
+  /** Full page HTML snapshot */
+  pageSnapshot: string;
+  /** Current page URL */
+  pageUrl: string;
+  /** The step that failed */
+  failedStep: SpecStep;
+  /** Error message */
+  error: string;
+  /** Interactive elements available on page */
+  availableElements: Array<{
+    type: string;
+    text?: string;
+    selector: string;
+    attributes?: Record<string, string>;
+  }>;
+  /** AI-generated suggestions for resolving the failure */
+  suggestions: string[];
+}
+
+/**
+ * Context passed to step execution
+ */
+export interface StepContext {
+  /** Index of current step */
+  stepIndex: number;
+  /** Total number of steps */
+  totalSteps: number;
+  /** Results from previous steps */
+  previousResults: StepResult[];
+  /** Current page state */
+  page: Page;
+  /** Stagehand instance */
+  stagehand: Stagehand;
+  /** Tester instance */
+  tester: Tester;
+}

--- a/lib/spec-test/types.ts
+++ b/lib/spec-test/types.ts
@@ -17,6 +17,17 @@ export interface SpecTestConfig {
   browserbaseApiKey?: string;
   /** Use headless browser (default: true) */
   headless?: boolean;
+  /**
+   * Directory for Stagehand action cache.
+   * When set, enables caching for 10-100x faster subsequent runs with zero token cost.
+   * Stagehand auto-generates cache keys from instruction + URL.
+   */
+  cacheDir?: string;
+  /**
+   * Create subdirectory per spec name (default: false).
+   * When true, cache path becomes: {cacheDir}/{spec-name}/
+   */
+  cachePerSpec?: boolean;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^2.0.57",
+    "@browserbasehq/stagehand": "^3.0.7",
     "@hookform/resolvers": "^5.2.2",
     "@libsql/client": "^0.15.15",
     "@radix-ui/react-accordion": "^1.2.12",
@@ -71,7 +72,7 @@
     "react-hook-form": "^7.65.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
-    "zod": "^4.1.12"
+    "zod": "^4.3.5"
   },
   "devDependencies": {
     "@playwright/test": "^1.56.1",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduces spec-test to run Epic-format behavior specs as browser tests using Stagehand for actions and B‑Test for checks, plus a spec-explorer script to generate specs from a live site. Adds caching, a CLI runner, fixtures, and tests.

- **New Features**
  - spec-test library: parses Epic specs, runs Act/Check steps, supports deterministic URL/title checks and semantic checks, provides failure context, and supports caching.
  - CLI runner (lib/spec-test/tests/run-spec.ts) and integration/unit tests with HTML fixtures.
  - spec-explorer script (explore.ts) to navigate a site and output an Epic-format spec; supports headless mode, step limits, and file output.
  - Updated B‑Test tester to work with both Playwright and Stagehand pages and improve HTML snapshot capture.

- **Dependencies**
  - Added @browserbasehq/stagehand ^3.0.7.
  - Updated zod to ^4.3.5.

<sup>Written for commit 2802fa435243f521a98cb2adb05f41fb06f59d52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

