### PR TITLE
Fix verify auth (localhost cookies) + dedicated verify server

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -15,10 +15,14 @@ Use `npx agent-browser` to drive the browser (fetched on demand — no install n
 # Isolated test DB: push schema + seed the 5 test users
 DATABASE_URL="file:./db/databases/test.db" bun run db:push
 DATABASE_URL="file:./db/databases/test.db" bun run db:seed   # writes db/seed/user.seed.ts
-# App on localhost:3001 with a localhost baseURL → non-secure cookies → HTTP auth works
-DATABASE_URL="file:./db/databases/test.db" NEXT_PUBLIC_BASE_URL="http://localhost:3001" \
+# App on localhost:3001 with a localhost baseURL → non-secure cookies → HTTP auth works.
+# DISABLE_WORKFLOW_BUILD=1 → skip the workflow esbuild bundler (the verify server
+# doesn't run workflows) so this 2nd `next dev` doesn't crash against the port-8080
+# server. NEXT_DIST_DIR=.next-verify → own build dir (no `.next` collision).
+DISABLE_WORKFLOW_BUILD=1 NEXT_DIST_DIR=.next-verify \
+  DATABASE_URL="file:./db/databases/test.db" NEXT_PUBLIC_BASE_URL="http://localhost:3001" \
   nohup bun run preview 3001 > /tmp/verify-server.log 2>&1 &
-until curl -sf http://localhost:3001 >/dev/null 2>&1; do sleep 1; done   # wait until ready
+until curl -sf http://localhost:3001 >/dev/null 2>&1; do sleep 1; done   # wait until ready (first compile ~30s)
 ```
 
 Then drive `http://localhost:3001` for every scenario. (The port-8080 preview stays untouched — it's the live app the human sees in the builder iframe.)

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -7,7 +7,21 @@ description: Verify that an implemented issue works by exercising its behavior i
 
 You are verifying that a web issue's implementation is working correctly by exercising it in the browser.
 
-Use `npx agent-browser` to drive the browser (fetched on demand — no install needed). The application is running at `http://localhost:8080` (use the port the user specifies if different).
+Use `npx agent-browser` to drive the browser (fetched on demand — no install needed). Verify runs against a **local verify server on `http://localhost:3001`** (isolated `test.db`), **not** the port-8080 preview: the 8080 dev server is configured for the cross-site iframe over the HTTPS proxy, so its auth cookies are `Secure`/`SameSite=None`/`Partitioned` and Chromium silently drops them over plain-HTTP `localhost` — sign-in appears to succeed but no session cookie sticks and every protected page bounces to `/signin`. The localhost verify server uses non-secure cookies (the auth config gates `Secure` on an HTTPS baseURL), so sign-in works.
+
+### Start the verify server (once, before driving scenarios)
+
+```bash
+# Isolated test DB: push schema + seed the 5 test users
+DATABASE_URL="file:./db/databases/test.db" bun run db:push
+DATABASE_URL="file:./db/databases/test.db" bun run db:seed   # writes db/seed/user.seed.ts
+# App on localhost:3001 with a localhost baseURL → non-secure cookies → HTTP auth works
+DATABASE_URL="file:./db/databases/test.db" NEXT_PUBLIC_BASE_URL="http://localhost:3001" \
+  nohup bun run preview 3001 > /tmp/verify-server.log 2>&1 &
+until curl -sf http://localhost:3001 >/dev/null 2>&1; do sleep 1; done   # wait until ready
+```
+
+Then drive `http://localhost:3001` for every scenario. (The port-8080 preview stays untouched — it's the live app the human sees in the builder iframe.)
 
 ## Workflow
 
@@ -49,7 +63,7 @@ Then re-read `db/seed/user.seed.ts` to pick up the generated credentials. `db:se
 
 When a scenario has a `#### PreDB` block, put the database into that state **before** driving its Steps. This is setup only — insert the rows the block names; you never read the database back to assert (PostDB checks are confirmed through the UI/network instead).
 
-Use the `PreDB` helper from `lib/db-test` (the same one the unit tests use). Write a throwaway script and run it against the **development** database — the one the preview app at `:8080` reads (`file:./db/databases/development.db`):
+Use the `PreDB` helper from `lib/db-test` (the same one the unit tests use). Write a throwaway script and run it against the **test** database the verify server reads (`file:./db/databases/test.db`):
 
 ```bash
 cat > /tmp/verify-setup.ts <<'EOF'
@@ -68,7 +82,7 @@ await PreDB(
 );
 process.exit(0);
 EOF
-NODE_ENV=development bun /tmp/verify-setup.ts
+DATABASE_URL="file:./db/databases/test.db" bun /tmp/verify-setup.ts
 ```
 
 - Pass `{ wipe: false }` so PreDB inserts the scenario's rows without deleting the seeded users — sign-in depends on them. Only use the default `wipe: true` (optionally scoped with `{ only: ["<table>"] }`) when the scenario owns that feature table outright and needs a clean slate. **Never wipe the auth/user tables.**
@@ -89,7 +103,7 @@ npx agent-browser install
 
 ```bash
 # open the browser and navigate
-npx agent-browser open http://localhost:8080
+npx agent-browser open http://localhost:3001
 # take a snapshot to see element refs (@e1, @e2, …)
 npx agent-browser snapshot
 # interact with the page using the @refs from the snapshot

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -15,17 +15,29 @@ Use `npx agent-browser` to drive the browser (fetched on demand — no install n
 # Isolated test DB: push schema + seed the 5 test users
 DATABASE_URL="file:./db/databases/test.db" bun run db:push
 DATABASE_URL="file:./db/databases/test.db" bun run db:seed   # writes db/seed/user.seed.ts
-# App on localhost:3001 with a localhost baseURL → non-secure cookies → HTTP auth works.
-# DISABLE_WORKFLOW_BUILD=1 → skip the workflow esbuild bundler (the verify server
-# doesn't run workflows) so this 2nd `next dev` doesn't crash against the port-8080
-# server. NEXT_DIST_DIR=.next-verify → own build dir (no `.next` collision).
-DISABLE_WORKFLOW_BUILD=1 NEXT_DIST_DIR=.next-verify \
+# NEXT_DIST_DIR=.next-verify → own build dir so this 2nd `next dev` doesn't collide
+# with the port-8080 server on `.next`.
+#
+# SAFEGUARD: skipping the workflow esbuild bundler (DISABLE_WORKFLOW_BUILD=1) is
+# what lets a 2nd `next dev` run without crashing the 8080 server's bundler — but
+# skipping it means workflow-backed features wouldn't run. So skip ONLY when the
+# app has NO workflow directives; if it uses workflows, run the FULL build so
+# verify never silently exercises a half-app.
+if grep -rslq -e "use workflow" -e "use step" app lib shared 2>/dev/null; then
+  WF_FLAG=""   # app HAS workflows → full workflow build (see note below)
+  echo "NOTE: app uses workflows — verify server runs the FULL workflow build."
+else
+  WF_FLAG="DISABLE_WORKFLOW_BUILD=1"   # no workflows → safe to skip, avoids the 2nd-server crash
+fi
+env $WF_FLAG NEXT_DIST_DIR=.next-verify \
   DATABASE_URL="file:./db/databases/test.db" NEXT_PUBLIC_BASE_URL="http://localhost:3001" \
   nohup bun run preview 3001 > /tmp/verify-server.log 2>&1 &
 until curl -sf http://localhost:3001 >/dev/null 2>&1; do sleep 1; done   # wait until ready (first compile ~30s)
 ```
 
 Then drive `http://localhost:3001` for every scenario. (The port-8080 preview stays untouched — it's the live app the human sees in the builder iframe.)
+
+> **If the app uses workflows** (the FULL-build path above): two concurrent workflow builds (this verify server + the port-8080 server) can conflict and crash the verify server's bundler. If the verify server fails to come up in that case, that's the concurrency limit — not a test failure: stop the port-8080 dev server for the duration of verify (or serve the app over local HTTPS as a single server), then re-run. Never fall back to the skip-workflow build for a workflow app — that would leave the feature under test unexercised.
 
 ## Workflow
 

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -23,6 +23,14 @@ function getParentDomain(url: string): string {
 
 const parentDomain = getParentDomain(baseUrl);
 
+// The iframe preview is served cross-site over the HTTPS proxy domain, which
+// requires Secure + SameSite=None + Partitioned cookies. But the verify phase
+// (and any localhost run) drives the app over http://localhost, where Chromium
+// silently drops Secure cookies — so sign-in "succeeds" but no session cookie
+// sticks and every protected page bounces to /signin. Gate the cookie hardening
+// on whether we're actually in a secure (https) context so localhost auth works.
+const isSecureContext = baseUrl.startsWith("https://");
+
 export const auth = betterAuth({
   plugins: [
     admin({
@@ -55,8 +63,8 @@ export const auth = betterAuth({
   trustedProxyHeaders: true,
   advanced: {
     cookiePrefix: "sandbox-auth",
-    useSecureCookies: true,
-    ...(parentDomain
+    useSecureCookies: isSecureContext,
+    ...(isSecureContext && parentDomain
       ? {
           crossSubDomainCookies: {
             enabled: true,
@@ -64,11 +72,16 @@ export const auth = betterAuth({
           },
         }
       : {}),
-    defaultCookieAttributes: {
-      sameSite: "none",
-      secure: true,
-      partitioned: true,
-    },
+    defaultCookieAttributes: isSecureContext
+      ? {
+          sameSite: "none",
+          secure: true,
+          partitioned: true,
+        }
+      : {
+          sameSite: "lax",
+          secure: false,
+        },
   },
 
   secret: process.env.BETTER_AUTH_SECRET,

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,9 @@ import { withWorkflow } from "workflow/next";
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  // Let a second (verify) dev server use its own build dir so two `next dev`
+  // instances in the same project don't collide on `.next`.
+  distDir: process.env.NEXT_DIST_DIR || ".next",
   devIndicators: false,
   allowedDevOrigins: ["*.http.cloud.morph.so", "*.epic.new", "*.lvh.me"],
   // Pin the Turbopack root to this checkout. Git worktrees live inside the
@@ -13,4 +16,12 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default withWorkflow(nextConfig);
+// The verify server serves the app to a browser for scenario checks and never
+// runs workflows. `withWorkflow` bundles workflow directives with esbuild, and
+// a second `next dev` running that bundler concurrently with the port-8080 dev
+// server panics esbuild (bundler conflict). Skip it for the verify server via
+// DISABLE_WORKFLOW_BUILD so two dev servers can coexist. The main app keeps the
+// full workflow build.
+export default process.env.DISABLE_WORKFLOW_BUILD
+  ? nextConfig
+  : withWorkflow(nextConfig);


### PR DESCRIPTION
## Make verify auth work + a dedicated localhost verify server

Fixes the remote-build verify phase, which was burning ~20 min per run fighting auth: the agent's sign-in over `http://localhost` never stuck, so every protected page bounced to `/signin`. Root cause + fixes, all empirically validated in a live Daytona sandbox.

### Root cause
The app's auth (`lib/auth/index.ts`) set `useSecureCookies: true` + `SameSite=None` + `Partitioned` **unconditionally** — required for the cross-site iframe over the HTTPS proxy, but Chromium **drops those cookies over plain-HTTP `localhost`**, where verify drives the app. So sign-in "succeeded" with no session cookie.

### Changes
- **`lib/auth/index.ts`** — gate the cookie hardening on an HTTPS baseURL. `https` (proxy/iframe) → `Secure`/`None`/`Partitioned` (unchanged). `http://localhost` (verify) → `SameSite=Lax`, non-secure → cookies stick, sign-in works. *Validated:* sign-up over `http://localhost` returns `Set-Cookie: …; SameSite=Lax` (no `Secure`).
- **`next.config.ts`** — `distDir` from `NEXT_DIST_DIR` (own build dir for a 2nd dev server), and skip `withWorkflow` when `DISABLE_WORKFLOW_BUILD=1`. Two `next dev` instances otherwise crash the workflow esbuild bundler (verified: `distDir` alone didn't fix it — the bundler was the culprit). Main app unchanged.
- **`.claude/skills/verify/SKILL.md`** — verify drives a dedicated **`http://localhost:3001`** server (own `distDir`, `test.db`, localhost baseURL) instead of the proxy-bound `:8080` preview. **Safeguard:** the workflow-build skip is *conditional on the app having no `use workflow`/`use step` directives* — if it does, verify runs the FULL build (never silently exercises a half-app). epic-web has 0 workflow usages today, so it's the skip path in practice.

### Validated in a real sandbox
- 2nd `next dev` (skip-workflow + own distDir) came up clean (`✓ Ready`, `GET / 200`) — no bundler crash.
- Sign-up over `http://localhost:3001` → `HTTP 200`, session cookie `SameSite=Lax` (no `Secure`) → auth sticks.
- Workflow-directive detection correctly selects the skip path on the current (workflow-free) repo.

### Note
Takes effect for sandboxes once merged and the Daytona snapshot is rebuilt (sandboxes clone this template at snapshot-build time). Companion changes: epic-cli remote run mode (#79) and epic-builder one-sandbox-per-issue (#885).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix localhost verify auth by gating secure cookie settings on HTTPS and running scenarios against a dedicated `http://localhost:3001` verify server. This removes long verify stalls from failed sign-ins and stabilizes remote-build verify.

- New Features
  - Dedicated verify server on `http://localhost:3001` with `test.db` and `NEXT_PUBLIC_BASE_URL=http://localhost:3001`.
  - Separate build dir via `NEXT_DIST_DIR` so two `next dev` instances don’t collide.
  - Optional skip of `withWorkflow` via `DISABLE_WORKFLOW_BUILD=1` to avoid esbuild conflicts; auto-detect workflow directives and run the full build when present.

- Bug Fixes
  - Auth cookies now depend on protocol: HTTPS → `Secure`/`SameSite=None`/`Partitioned`; HTTP (localhost) → `SameSite=Lax`, non-secure.
  - Only enables cross-subdomain cookies when HTTPS and a parent domain exist.

<sup>Written for commit 6ce85e2ef287096f3dd51041ef7dc2c01a4be418. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/epicnew/epic-web/pull/34?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

