### PR TITLE
feat(spec): idempotent spec:server shared by execute and verify phases

### DIFF
--- a/.claude/skills/execute/SKILL.md
+++ b/.claude/skills/execute/SKILL.md
@@ -190,9 +190,23 @@ Create a single Playwright test that:
 
 ### Running the Behavior Test:
 
+Specs target the URL in the `BASE_URL` environment variable (loaded from
+`.env.test` by `playwright.config.ts`). If nothing is listening there yet
+(common in a remote sandbox, where `BASE_URL` points at a dedicated spec
+server, not the port-8080 preview), boot it once:
+
 ```bash
+bun run spec:server   # idempotent — reuses the server if already running
 bun run spec [behavior-name].spec.ts
 ```
+
+**Never point specs at the port-8080 preview and never edit `.env.test`.**
+In a remote sandbox the 8080 server is configured for the cross-site iframe
+over the HTTPS proxy, so its auth cookies are `Secure`/`SameSite=None` and
+Chromium silently drops them over plain-HTTP localhost — sign-in appears to
+succeed but no session cookie sticks and every protected page bounces to
+`/signin`. The spec server (`bun run spec:server`) runs with a localhost
+base URL and non-secure cookies, so sign-in works.
 
 **Check the logs after test completes:**
 ```bash
@@ -236,7 +250,7 @@ This shows the last 100 lines of logs to see what happened during the test.
 4. **Clean Up**: Remove test data after tests
 
 **For Behavior Tests:**
-1. **Base URL**: Always use `const baseUrl = 'http://localhost:8080';`
+1. **Base URL**: Never hardcode a URL — use relative paths (`page.goto('/')`) so Playwright's configured `baseURL` (from `BASE_URL` / `.env.test`) applies
 2. **Authentication**: Use `test.use({ storageState: '.auth/user.json' });` for auth-required pages
 3. **Data Test IDs**: Ensure all interactive elements have `data-testid` attributes
 4. **Real Workflows**: Test actual user behavior, not just happy paths

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -12,28 +12,15 @@ Use `npx agent-browser` to drive the browser (fetched on demand — no install n
 ### Start the verify server (once, before driving scenarios)
 
 ```bash
-# Isolated test DB: push schema + seed the 5 test users
-DATABASE_URL="file:./db/databases/test.db" bun run db:push
-DATABASE_URL="file:./db/databases/test.db" bun run db:seed   # writes db/seed/user.seed.ts
-# NEXT_DIST_DIR=.next-verify → own build dir so this 2nd `next dev` doesn't collide
-# with the port-8080 server on `.next`.
-#
-# SAFEGUARD: skipping the workflow esbuild bundler (DISABLE_WORKFLOW_BUILD=1) is
-# what lets a 2nd `next dev` run without crashing the 8080 server's bundler — but
-# skipping it means workflow-backed features wouldn't run. So skip ONLY when the
-# app has NO workflow directives; if it uses workflows, run the FULL build so
-# verify never silently exercises a half-app.
-if grep -rslq -e "use workflow" -e "use step" app lib shared 2>/dev/null; then
-  WF_FLAG=""   # app HAS workflows → full workflow build (see note below)
-  echo "NOTE: app uses workflows — verify server runs the FULL workflow build."
-else
-  WF_FLAG="DISABLE_WORKFLOW_BUILD=1"   # no workflows → safe to skip, avoids the 2nd-server crash
-fi
-env $WF_FLAG NEXT_DIST_DIR=.next-verify \
-  DATABASE_URL="file:./db/databases/test.db" NEXT_PUBLIC_BASE_URL="http://localhost:3001" \
-  nohup bun run preview 3001 > /tmp/verify-server.log 2>&1 &
-until curl -sf http://localhost:3001 >/dev/null 2>&1; do sleep 1; done   # wait until ready (first compile ~30s)
+bun run spec:server   # idempotent — reuses the server if the execute phase already booted it
 ```
+
+The script (`scripts/spec-server.sh`) owns the whole recipe: isolated
+`test.db` (schema push + seeded users), `NEXT_DIST_DIR=.next-verify` so this
+2nd `next dev` doesn't collide with the port-8080 server on `.next`, the
+workflow-build safeguard (full build when the app has `use workflow` /
+`use step` directives, `DISABLE_WORKFLOW_BUILD=1` otherwise), and a readiness
+wait. Logs land in `/tmp/spec-server.log`.
 
 Then drive `http://localhost:3001` for every scenario. (The port-8080 preview stays untouched — it's the live app the human sees in the builder iframe.)
 

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ pnpm-lock.yaml
 
 # next.js
 /.next/
+/.next-verify/
 /out/
 
 # production

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "typecheck": "npx tsgo --noEmit --skipLibCheck",
     "test": "NODE_ENV=test vitest run --reporter=verbose",
     "spec": "playwright test --reporter=list",
+    "spec:server": "bash scripts/spec-server.sh",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
     "db:generate": "drizzle-kit generate",

--- a/scripts/spec-server.sh
+++ b/scripts/spec-server.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Idempotent boot of the SPEC SERVER — the localhost server behavior specs and
+# verify scenarios run against. Reused by the execute and verify phases: the
+# first caller boots it, later callers detect it and exit 0.
+#
+# Why a dedicated server instead of the port-8080 preview: in a remote sandbox
+# the 8080 dev server is configured for the cross-site iframe over the HTTPS
+# proxy, so its auth cookies are Secure/SameSite=None/Partitioned and Chromium
+# silently drops them over plain-HTTP localhost — sign-in returns 200 but no
+# session cookie sticks. This server's NEXT_PUBLIC_BASE_URL is localhost, so
+# the auth config issues non-secure cookies and sign-in works.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Target URL comes from .env.test's BASE_URL (written by the epic provisioning);
+# conventional default is 3001.
+BASE_URL_LINE=$(grep -E '^[[:space:]]*BASE_URL=' .env.test 2>/dev/null | tail -1 || true)
+URL=$(echo "${BASE_URL_LINE#*=}" | tr -d '"' | tr -d '[:space:]')
+URL=${URL:-http://localhost:3001}
+PORT=${URL##*:}
+
+# Already serving? Reuse it.
+if curl -sf "$URL" >/dev/null 2>&1; then
+  echo "spec server already running at $URL"
+  exit 0
+fi
+
+# Only a localhost URL can be booted here. A non-local BASE_URL means the
+# environment intends specs to hit an external server — nothing to do.
+case "$URL" in
+  http://localhost:* | http://127.0.0.1:*) ;;
+  *)
+    echo "BASE_URL=$URL is not local — refusing to boot a spec server" >&2
+    exit 1
+    ;;
+esac
+
+# Isolated test DB: schema + seeded users.
+DATABASE_URL="file:./db/databases/test.db" bun run db:push
+DATABASE_URL="file:./db/databases/test.db" bun run db:seed
+
+# SAFEGUARD: skipping the workflow esbuild bundler (DISABLE_WORKFLOW_BUILD=1) is
+# what lets a 2nd `next dev` run without crashing the 8080 server's bundler — but
+# skipping it means workflow-backed features wouldn't run. So skip ONLY when the
+# app has NO workflow directives; if it uses workflows, run the FULL build so
+# specs never silently exercise a half-app.
+if grep -rslq -e "use workflow" -e "use step" app lib shared 2>/dev/null; then
+  WF_FLAG=""
+  echo "NOTE: app uses workflows — spec server runs the FULL workflow build."
+else
+  WF_FLAG="DISABLE_WORKFLOW_BUILD=1"
+fi
+
+# NEXT_DIST_DIR=.next-verify → own build dir so this 2nd `next dev` doesn't
+# collide with the port-8080 server on `.next`.
+env $WF_FLAG NEXT_DIST_DIR=.next-verify \
+  DATABASE_URL="file:./db/databases/test.db" NEXT_PUBLIC_BASE_URL="$URL" \
+  nohup bun run preview "$PORT" >/tmp/spec-server.log 2>&1 &
+
+# First compile takes ~30-60s.
+for _ in $(seq 1 120); do
+  if curl -sf "$URL" >/dev/null 2>&1; then
+    echo "spec server ready at $URL"
+    exit 0
+  fi
+  sleep 1
+done
+echo "spec server did not become ready within 120s — see /tmp/spec-server.log" >&2
+exit 1


### PR DESCRIPTION
## Problem

Observed in a real remote build (CHE-5 on staging): the **execute phase has no localhost spec target**. `.env.test`'s `BASE_URL` (localhost:3001) points at a server only the verify skill knew how to boot, so the execute agent redirected specs at the port-8080 preview — whose proxy-domain `Secure`/`SameSite=None` cookies Chromium silently drops over plain-HTTP localhost. Sign-in returns 200, no session sticks, and the agent burned ~30 min rewriting the spec ~6 times. The verify agent, on a stale-template project, improvised ad-hoc Playwright scripts against 8080 and hit the same wall.

## Change

- **`scripts/spec-server.sh` + `bun run spec:server`** — one canonical, idempotent boot: reuse the server if already up; otherwise `test.db` push + seed, workflow-build safeguard (full build when `use workflow`/`use step` directives exist, `DISABLE_WORKFLOW_BUILD=1` otherwise), `NEXT_DIST_DIR=.next-verify`, readiness wait.
- **execute skill** — boot `spec:server` when `BASE_URL` refuses connection; never edit `.env.test` or point specs at the 8080 preview (cookie trap documented); removed the hardcoded `baseUrl = 'http://localhost:8080'` rule in favor of relative paths + configured `baseURL`.
- **verify skill** — replaced its inline 20-line boot recipe with `spec:server`, so verify reuses the server execute booted.
- **`.gitignore`** — `/.next-verify/`.

## Validation

- Booted locally: server ready on 3001; second invocation returns "already running" in 17ms.
- Cookie contract confirmed: sign-in over `http://localhost:3001` sets `sandbox-auth.session_token` with `SameSite=Lax` and **no** `Secure` flag.

Pairs with epicnew/epic-cli's `feat/execute-spec-server` (orchestrator pre-boots this server in remote run mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an idempotent localhost spec server shared by execute and verify to stop specs from hitting the 8080 preview and failing auth due to dropped `Secure`/`SameSite=None` cookies (seen in CHE-5).

- **New Features**
  - `scripts/spec-server.sh` + `bun run spec:server`: reuse if running; push/seed isolated `test.db`; `NEXT_DIST_DIR=.next-verify`; workflow-build safeguard (`DISABLE_WORKFLOW_BUILD=1` unless `use workflow`/`use step` found); readiness wait; logs to `/tmp/spec-server.log`.
  - Execute: auto-boot `spec:server` if `BASE_URL` is unreachable; stop editing `.env.test`; remove hardcoded `baseUrl`; use relative paths with configured `baseURL`.
  - Verify: replace inline boot with `spec:server`, reusing the server started by execute.
  - Repo: add `"spec:server": "bash scripts/spec-server.sh"` to `package.json`; ignore `/.next-verify/` in `.gitignore`.

<sup>Written for commit f38ab795b0f62eb6c3ef681251ceecbf7cc80482. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/epicnew/epic-web/pull/35?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

