### PR TITLE
fix(db): regenerate migrations baseline to match schema.ts

### DIFF
--- a/db/migrations/0000_sturdy_skullbuster.sql
+++ b/db/migrations/0000_sturdy_skullbuster.sql
@@ -15,24 +15,6 @@ CREATE TABLE `account` (
 	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
 );
 --> statement-breakpoint
-CREATE TABLE `auth_tokens` (
-	`token` text PRIMARY KEY NOT NULL,
-	`email` text NOT NULL,
-	`callback_url` text,
-	`ua_hash` text,
-	`expires_at` integer NOT NULL,
-	`consumed_at` integer,
-	`created_at` integer NOT NULL
-);
---> statement-breakpoint
-CREATE TABLE `magic_links` (
-	`cid` text PRIMARY KEY NOT NULL,
-	`email` text NOT NULL,
-	`verify_url` text NOT NULL,
-	`expires_at` integer NOT NULL,
-	`created_at` integer NOT NULL
-);
---> statement-breakpoint
 CREATE TABLE `session` (
 	`id` text PRIMARY KEY NOT NULL,
 	`expires_at` integer NOT NULL,

--- a/db/migrations/meta/0000_snapshot.json
+++ b/db/migrations/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "9962c6ee-e984-455d-868b-d3fc2d81c05a",
+  "id": "7f678f46-5288-4b75-bdc7-d6d7eb3b519e",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "account": {
@@ -115,110 +115,6 @@
           "onUpdate": "no action"
         }
       },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "checkConstraints": {}
-    },
-    "auth_tokens": {
-      "name": "auth_tokens",
-      "columns": {
-        "token": {
-          "name": "token",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "email": {
-          "name": "email",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "callback_url": {
-          "name": "callback_url",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "ua_hash": {
-          "name": "ua_hash",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "consumed_at": {
-          "name": "consumed_at",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "checkConstraints": {}
-    },
-    "magic_links": {
-      "name": "magic_links",
-      "columns": {
-        "cid": {
-          "name": "cid",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "email": {
-          "name": "email",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "verify_url": {
-          "name": "verify_url",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "checkConstraints": {}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "6",
-      "when": 1762802019042,
-      "tag": "0000_flimsy_paibok",
+      "when": 1783556494770,
+      "tag": "0000_sturdy_skullbuster",
       "breakpoints": true
     }
   ]


### PR DESCRIPTION
## Problem

The `0000` migrations baseline still created `auth_tokens` and `magic_links` — tables removed from `db/schema.ts` in 01eed1f (switch to the native Better Auth magic link plugin). The stale snapshot had two consequences for every project cloned from this template:

1. Any `drizzle-kit generate` proposed **dropping those two tables** — a destructive change agents could accidentally commit alongside their own migration.
2. The interactive rename prompt ("Is X table created or renamed from another table?") appeared on every new-table migration, stalling headless build agents (observed in a staging one-sandbox-per-issue run: the agent burned ~6 turns and ended up driving the prompt with a Python `pty` hack).

## Fix

Squashed via `bun run db:squash` and regenerated with `bun run db:generate`. The baseline now contains exactly the four schema tables: `user`, `session`, `account`, `verification`.

## Verification

- `bun run db:migrate` applies cleanly on a fresh database; resulting tables match the schema exactly
- A follow-up `bun run db:generate` is a no-op ("No schema changes, nothing to migrate")
- `grep` confirms no code references `auth_tokens` / `magic_links`

## Notes

- Only affects **new** projects cloned from the template; existing project repos keep their own migration history (known template-drift limitation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Regenerated the 0000 migration baseline to match db/schema.ts and remove the old auth tables. This prevents `drizzle-kit` from proposing destructive drops and avoids interactive prompts in CI.

- **Bug Fixes**
  - Baseline now only includes: user, session, account, verification.
  - Fresh DB: migrate applies cleanly, then generate is a no-op.
  - Affects only new projects cloned from the template.

<sup>Written for commit 2e8d052de9f2e366c1132c6f8734ac4ac3387256. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/epicnew/epic-web/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

