### PR TITLE
fix(skill): verify — one browser session at a time; never pkill the servers

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -56,10 +56,11 @@ If `userSeeds` is empty (or `db/seed/user.seed.ts` is missing), **seed the datab
 bun run db:seed   # creates the 5 test users and writes db/seed/user.seed.ts
 ```
 
-Then re-read `db/seed/user.seed.ts` to pick up the generated credentials. `db:seed` is safe to re-run — existing users are skipped. Reach for `bun run db:reset` only when the schema is stale and you need a clean rebuild; it drops all data, so re-seed afterward.
+Then re-read `db/seed/user.seed.ts` to pick up the generated credentials — it resolves the credential set for the CURRENT `DATABASE_URL`, so always read it (and run `db:seed`) with the same `DATABASE_URL` the verify server uses. `db:seed` is safe to re-run — existing users are reconciled in place (real ids read back, passwords re-aligned), so the credentials it leaves behind always sign in. Reach for `bun run db:reset` only when the schema is stale and you need a clean rebuild; it drops all data, so re-seed afterward.
 
 - Assign one distinct user per scenario, round-robin by scenario order (`userSeeds[(N - 1) % userSeeds.length]`). One user per scenario keeps data created by one scenario from bleeding into the next. With 5 seeded users, the first five scenarios each get a unique user.
-- Optionally pair each scenario with its own `npx agent-browser --session <name>` jar (e.g. `--session scenario-1`) so the assigned user and the browser storage stay isolated per scenario.
+- **One browser session at a time.** Each `--session <name>` is a FULL Chrome instance, and the sandbox has a hard memory cgroup shared with two dev servers — parallel sessions get the OOM killer shooting Chrome and the servers mid-scenario (symptoms: pages stuck on "Loading...", "Under Construction" for routes that exist, sign-ins that never land). Run scenarios sequentially in one session, and when the next scenario needs a different user, `npx agent-browser --session <name> close` the previous session (or just sign out) BEFORE opening the next. Never keep more than one session alive.
+- **Never `pkill` the dev/next servers as memory triage** — the verify server on 3001 is one of them; killing it destroys your own test target and its compiled routes. Close browser sessions instead; that's where the memory goes.
 - To authenticate, navigate to the signin page and fill the assigned user's `email` and `password`, then submit and confirm the redirect to the authenticated home page before proceeding with the scenario's steps.
 
 ## Setting up scenario state


### PR DESCRIPTION
## Summary
E2e run 4 root cause for the verify loop: the skill's per-scenario `--session` guidance spawns one full Chrome per scenario on a 4GB-cgroup sandbox already running two Next dev servers → 22 OOM kills, and the agent chased the symptoms ("Under Construction" on existing routes, sign-ins never landing) then `pkill`ed next-server — its own verify target.

- One browser session at a time; close before switching users; never more than one alive.
- Never kill the dev/next servers as memory triage — that's the verify server.
- `db:seed` wording aligned with the reconcile semantics from #37.

Companion fixes for the same run: #37 (seed reconciliation), epicnew/epic-cli#83 (commit excludes). All three should merge before the next snapshot rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened verify skill guidance to run one browser session at a time and never kill dev servers, preventing OOM crashes and flaky sign-ins during e2e runs. Clarifies `db:seed` reconciliation so credentials always match the current `DATABASE_URL`.

- **Bug Fixes**
  - Use a single browser `--session`; close it before switching users to avoid parallel Chrome instances.
  - Do not `pkill` dev/Next servers; the verify target runs there.
  - Update `db:seed` docs: reconcile users in place and resolve creds for the active `DATABASE_URL`.

<sup>Written for commit 4699b4199367ac1bb0acc140f339dc70e56e2bbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/epicnew/epic-web/pull/38?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

