### PR TITLE
fix(template): make the agent's test loop run green out of the box

### DIFF
--- a/app/admin/database/[tableName]/behaviors/add-row/tests/insert-row.action.test.ts
+++ b/app/admin/database/[tableName]/behaviors/add-row/tests/insert-row.action.test.ts
@@ -1,4 +1,20 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// These actions gate on getUser() -> next/headers, which only exists inside a
+// real request scope. Mock both (same pattern as the admin/users tests) so the
+// action logic runs under vitest.
+vi.mock("next/headers", () => ({
+  headers: vi.fn(() => Promise.resolve(new Headers())),
+}));
+vi.mock("@/lib/auth", async () => {
+  const actual = await vi.importActual("@/lib/auth");
+  return {
+    ...actual,
+    getUser: vi.fn(() =>
+      Promise.resolve({ user: { id: "admin-test", role: "admin" } }),
+    ),
+  };
+});
 import { db } from "@/db";
 import * as schema from "@/db/schema";
 import { PreDB } from "@/lib/db-test";

--- a/app/admin/database/[tableName]/behaviors/delete-row/tests/delete-row.action.test.ts
+++ b/app/admin/database/[tableName]/behaviors/delete-row/tests/delete-row.action.test.ts
@@ -1,4 +1,20 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// These actions gate on getUser() -> next/headers, which only exists inside a
+// real request scope. Mock both (same pattern as the admin/users tests) so the
+// action logic runs under vitest.
+vi.mock("next/headers", () => ({
+  headers: vi.fn(() => Promise.resolve(new Headers())),
+}));
+vi.mock("@/lib/auth", async () => {
+  const actual = await vi.importActual("@/lib/auth");
+  return {
+    ...actual,
+    getUser: vi.fn(() =>
+      Promise.resolve({ user: { id: "admin-test", role: "admin" } }),
+    ),
+  };
+});
 import { db } from "@/db";
 import * as schema from "@/db/schema";
 import { PreDB } from "@/lib/db-test";

--- a/app/admin/database/[tableName]/behaviors/edit-row/tests/update-row.action.test.ts
+++ b/app/admin/database/[tableName]/behaviors/edit-row/tests/update-row.action.test.ts
@@ -1,4 +1,20 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// These actions gate on getUser() -> next/headers, which only exists inside a
+// real request scope. Mock both (same pattern as the admin/users tests) so the
+// action logic runs under vitest.
+vi.mock("next/headers", () => ({
+  headers: vi.fn(() => Promise.resolve(new Headers())),
+}));
+vi.mock("@/lib/auth", async () => {
+  const actual = await vi.importActual("@/lib/auth");
+  return {
+    ...actual,
+    getUser: vi.fn(() =>
+      Promise.resolve({ user: { id: "admin-test", role: "admin" } }),
+    ),
+  };
+});
 import { db } from "@/db";
 import * as schema from "@/db/schema";
 import { PreDB } from "@/lib/db-test";

--- a/app/admin/database/[tableName]/behaviors/view-table/tests/fetch-table-data.action.test.ts
+++ b/app/admin/database/[tableName]/behaviors/view-table/tests/fetch-table-data.action.test.ts
@@ -1,4 +1,20 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// These actions gate on getUser() -> next/headers, which only exists inside a
+// real request scope. Mock both (same pattern as the admin/users tests) so the
+// action logic runs under vitest.
+vi.mock("next/headers", () => ({
+  headers: vi.fn(() => Promise.resolve(new Headers())),
+}));
+vi.mock("@/lib/auth", async () => {
+  const actual = await vi.importActual("@/lib/auth");
+  return {
+    ...actual,
+    getUser: vi.fn(() =>
+      Promise.resolve({ user: { id: "admin-test", role: "admin" } }),
+    ),
+  };
+});
 import { db } from "@/db";
 import * as schema from "@/db/schema";
 import { PreDB } from "@/lib/db-test";

--- a/app/admin/database/behaviors/list-tables/tests/fetch-tables.action.test.ts
+++ b/app/admin/database/behaviors/list-tables/tests/fetch-tables.action.test.ts
@@ -1,4 +1,20 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// These actions gate on getUser() -> next/headers, which only exists inside a
+// real request scope. Mock both (same pattern as the admin/users tests) so the
+// action logic runs under vitest.
+vi.mock("next/headers", () => ({
+  headers: vi.fn(() => Promise.resolve(new Headers())),
+}));
+vi.mock("@/lib/auth", async () => {
+  const actual = await vi.importActual("@/lib/auth");
+  return {
+    ...actual,
+    getUser: vi.fn(() =>
+      Promise.resolve({ user: { id: "admin-test", role: "admin" } }),
+    ),
+  };
+});
 import { db } from "@/db";
 import * as schema from "@/db/schema";
 import { PreDB } from "@/lib/db-test";

--- a/db/seed/seed-store.ts
+++ b/db/seed/seed-store.ts
@@ -22,7 +22,12 @@ export type UserSeed = {
   userId: string;
 };
 
-const CREDENTIALS_DIR = join(import.meta.dir, ".credentials");
+// process.cwd()-based, NOT import.meta.dir: `import.meta.dir` is a Bun-only
+// API and this module is also loaded by Playwright under NODE (every spec
+// imports user.seed.ts -> here), where it crashed the whole spec run at
+// module load. Seed and specs always run from the repo root (bun run /
+// playwright.config.ts live there), so cwd-relative is stable.
+const CREDENTIALS_DIR = join(process.cwd(), "db", "seed", ".credentials");
 
 /** DATABASE_URL → stable per-database key (`test`, `development`, …). */
 export function seedDbKey(


### PR DESCRIPTION
## Summary
Follow-up to #39 — this commit was pushed to `feat/sterile-template` minutes after the PR merged, so it never landed on main. Cherry-picked onto a fresh branch.

Two template-shipped failures that burned agent turns on every sandbox run:

- **`db/seed/seed-store.ts` used `import.meta.dir` (Bun-only API)**: `db:seed` under bun worked, but Playwright loads the module under Node (every spec imports `user.seed.ts` → `seed-store.ts`) and the whole spec run died at module load. Now resolves the credentials dir from `process.cwd()`.
- **The five `app/admin/database` action tests had no mocks** — real actions hit `getUser()` → `next/headers` outside a request scope (28 failures). They now mock `next/headers` + `@/lib/auth` exactly like the `admin/users` tests already did.

## Verification (as the sandbox agent runs it)
`bun run spec:server` (fresh test.db) → `bun run spec` **3/3** → `bun run test` **135/135** → typecheck clean → `git status` shows zero runtime churn afterwards (sterile-template check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the template’s test loop pass on fresh runs by fixing seed path resolution and adding mocks so admin database action tests run outside a request scope.

- **Bug Fixes**
  - Seed store: replaced `import.meta.dir` with `process.cwd()` in `db/seed/seed-store.ts` to avoid Node crashes when the module loads.
  - Tests: mocked `next/headers` and `@/lib/auth` in the five admin database action test files so `getUser()` checks work under `vitest`.

<sup>Written for commit 568aac82a4e612dce72f8f8f4d23d4e531900524. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/epicnew/epic-web/pull/40?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

