### PR TITLE
fix(preview): trust the sandbox's own host in both origin allowlists

### DIFF
--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -55,6 +55,13 @@ export const auth = betterAuth({
     additionalFields: {},
   },
   trustedOrigins: [
+    // This app's own origin, verbatim. The wildcard below is derived from the
+    // PARENT domain (the last two labels), and one `*` matches one label — so
+    // for a preview served at `https://8080-<sandbox>.proxy.epic.new` the
+    // pattern `https://*.epic.new` does not match, and Better Auth answers
+    // 403 to its own sign-in form. Listing baseUrl removes the guesswork:
+    // whatever host this app believes it is served from is trusted.
+    baseUrl,
     ...(parentDomain
       ? [`https://${parentDomain}`, `https://*.${parentDomain}`]
       : []),

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,7 +6,18 @@ const nextConfig: NextConfig = {
   // instances in the same project don't collide on `.next`.
   distDir: process.env.NEXT_DIST_DIR || ".next",
   devIndicators: false,
-  allowedDevOrigins: ["*.http.cloud.morph.so", "*.epic.new", "*.lvh.me"],
+  // A wildcard label matches ONE label, so "*.epic.new" does not cover
+  // "8080-<sandbox>.proxy.epic.new" — the preview host is a level deeper.
+  // Without the deeper pattern Next blocks its own dev resources as
+  // cross-origin, React never hydrates, and the page renders perfectly while
+  // every form on it is inert: a click submits nothing, and the verify agent
+  // reports it as failing scenarios rather than as a broken environment.
+  allowedDevOrigins: [
+    "*.proxy.epic.new",
+    "*.http.cloud.morph.so",
+    "*.epic.new",
+    "*.lvh.me",
+  ],
   // Pin the Turbopack root to this checkout. Git worktrees live inside the
   // repo (.worktrees/*), so lockfile inference would otherwise resolve the
   // workspace root to the parent checkout and share its .next/dev/lock,


### PR DESCRIPTION
## Root cause

A wildcard label matches exactly **one** label. The preview is served at

```
https://8080-<sandbox>.proxy.epic.new
```

which is one level deeper than the `epic.new` parent domain both allowlists are derived from. So `*.epic.new` never matched it.

```
origin       : https://8080-c445da21-….proxy.epic.new   (4 labels)
allowed      : https://*.epic.new                        (covers 1 label)
```

Two separate failures fall out of that, and together they are why **verify could not sign in inside a sandbox**.

## 1. Next blocked its own dev resources → React never hydrated

From the sandbox's `pm2` dev log:

```
⚠ Blocked cross-origin request to Next.js dev resource
  /__nextjs_font/geist-latin.woff2 from "8080-….proxy.epic.new"
  → add it to "allowedDevOrigins"
```

The page server-renders perfectly. The accessibility snapshot looks right. The fields accept text. **And the form is inert** — a click on SIGN IN produced no network request at all.

What made this hard to see: it presents as a product bug, not an environment one. I tried three input methods before suspecting hydration — `fill`+`click`, `fill`+Enter, and `focus`+real keystrokes — none produced a POST. It was the dev-server log, not the browser, that named the cause.

## 2. Better Auth 403'd its own sign-in form

```
POST /api/auth/sign-in/email 403
```

Same gap: the request Origin was not in `trustedOrigins`. Listing `baseUrl` verbatim removes the guesswork — whatever host this app believes it is served from is trusted. The parent-domain wildcards stay for the iframe/parent cases.

## Not affected: the cookie Domain

It stays `epic.new`, and should. A cookie must be set on the registrable domain, and the browser accepts it because the host ends with it. Only the **origin** checks needed the deeper host.

## Verified live

On a sandbox from the current snapshot, patched in place and restarted.

| | Before | After |
|---|---|---|
| sign-in POST | none | `GET / 200` |
| landing | stuck on `/auth/signin` | `heading "Welcome to Home Page"` |
| `/api/auth/get-session` | `null` | `user-1@gmail.com` |
| session across navigation | — | survives |

## Rollout

This is the template repo, so the fix reaches new sandboxes only after the image is rebuilt from it. **Existing project repos are clones and carry the old config** — they will need the same two-line change, or a migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trust the sandbox preview host in both origin allowlists so previews hydrate and sign-in works. `*.epic.new` didn’t match `8080-<sandbox>.proxy.epic.new`, causing blocked dev assets and 403s.

- **Bug Fixes**
  - Next dev server: add `"*.proxy.epic.new"` to `allowedDevOrigins` so dev assets load and React hydrates.
  - Auth: add `baseUrl` to `trustedOrigins` so the sandbox sign-in POST is accepted.

- **Migration**
  - Existing project repos cloned from this template need the same changes until the image is rebuilt.

<sup>Written for commit da07f6672dcad18d646725edb0d5f5333da829eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/epic-new/epic-web/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

