### PR TITLE
docs(verify): read credentials from .credentials/, not the loader module

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -33,7 +33,13 @@ There is no separate verify server to boot: the preview is already running (supe
 
 **If the prompt contains a "Test credentials" block, use it directly and skip this section entirely** — the harness already read the seeded users; do not `cat` seed files or run `db:seed`.
 
-Fallback (no block in the prompt): the credentials live in `db/seed/user.seed.ts`, exported as the `userSeeds` array (`email`, `password`, `name`, `userId`; passwords are generated per environment — never assume a default). Read them with `cat db/seed/user.seed.ts`. If `userSeeds` is empty or the file is missing, run `bun run db:seed` (safe to re-run; reconciles in place) with the same `DATABASE_URL` the preview uses (the one in `.env`), then re-read. `bun run db:reset` only when the schema is stale — it drops all data.
+Fallback (no block in the prompt): the values live in `db/seed/.credentials/user-seeds.<db>.json`, written by `bun run db:seed` and keyed by the database the preview targets. `db/seed/user.seed.ts` exports them as the `userSeeds` array (`email`, `password`, `name`, `userId`; passwords are generated per environment — never assume a default), but it is only a loader — `cat`-ing it shows the loading code, not the credentials. Read the JSON file directly:
+
+```bash
+cat db/seed/.credentials/user-seeds.*.json
+```
+
+If no such file exists, run `bun run db:seed` (safe to re-run; reconciles in place) with the same `DATABASE_URL` the preview uses (the one in `.env`), then re-read. `bun run db:reset` only when the schema is stale — it drops all data.
 
 - Assign one distinct user per scenario, round-robin by scenario order (`userSeeds[(N - 1) % userSeeds.length]`). One user per scenario keeps data created by one scenario from bleeding into the next. With 5 seeded users, the first five scenarios each get a unique user.
 - **One browser session at a time.** Each `--session <name>` is a FULL Chrome instance, and the sandbox has a hard memory cgroup shared with two dev servers — parallel sessions get the OOM killer shooting Chrome and the servers mid-scenario (symptoms: pages stuck on "Loading...", "Under Construction" for routes that exist, sign-ins that never land). Run scenarios sequentially in one session, and when the next scenario needs a different user, `npx agent-browser --session <name> close` the previous session (or just sign out) BEFORE opening the next. Never keep more than one session alive.


### PR DESCRIPTION
Mirrors [epic-cli#95](https://github.com/epic-new/epic-cli/pull/95).

`db/seed/user.seed.ts` exports `userSeeds` via `loadUserSeeds()` — a loader. `cat`-ing it shows loading code and no credentials. The values live in `db/seed/.credentials/user-seeds.<db>.json`, which is also where the verify harness reads from (`loadTestCredentials`).

This is the copy that **actually runs inside a sandbox**; the epic-cli one is the source that `epic skill install` writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update verify docs to read seeded credentials from `db/seed/.credentials/user-seeds.<db>.json` instead of the `db/seed/user.seed.ts` loader, matching the harness’s read path. Also adds a quick `cat` example and clarifies the fallback to `bun run db:seed` using the preview’s `DATABASE_URL`.

<sup>Written for commit 16e75a5c48ea770246b6ea4813fec0e8f91f1d05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/epic-new/epic-web/pull/44?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

