### PR TITLE
fix(spec): cross the proxy gate before authenticating

### DIFF
--- a/app/auth/signin/behaviors/auth-setup/tests/auth.setup.ts
+++ b/app/auth/signin/behaviors/auth-setup/tests/auth.setup.ts
@@ -5,6 +5,23 @@ import { HOME_URL, SIGNIN_URL } from '@/app.config';
 const authFile = 'playwright/.auth/user.json';
 
 setup('authenticate', async ({ page }) => {
+  // In a sandbox the preview is served through epic-proxy, which gates the
+  // public URL on an ownership token. Without it every request is a 403 that
+  // renders as an "Access Denied" page — indistinguishable, to a browser
+  // driver, from an app that has not booted.
+  //
+  // Hitting the URL once with the token makes the proxy set its
+  // `epic_proxy_auth` cookie and redirect to the clean path. From then on the
+  // whole context carries it, and because this runs before `storageState` is
+  // written, every dependent project inherits it too.
+  //
+  // Unset outside a sandbox (local runs reach the dev server directly), so
+  // this is a no-op there.
+  const proxyToken = process.env.EPIC_PROXY_TOKEN;
+  if (proxyToken) {
+    await page.goto(`/?_proxy_token=${encodeURIComponent(proxyToken)}`);
+  }
+
   // Perform authentication steps
   await page.goto(SIGNIN_URL);
   await page.fill('input[name="email"]', userSeeds[0].email);


### PR DESCRIPTION
In a sandbox the preview is served through **epic-proxy**, which gates the public URL on an ownership token.

The verify agent gets one (`remoteVerifyUrl` mints it). The Playwright harness never did — so `bun run spec` met a **403 rendered as an "Access Denied" page**, which a browser driver cannot tell from an app that has not booted.

Caught live: an agent spent an entire execute phase reading `error-context.md` and curling the preview URL in a loop, trying to work out why its auth setup failed. The answer was a missing query parameter.

## The fix

Load the URL once with the token. The proxy sets its `epic_proxy_auth` cookie and redirects to the clean path; because this runs **before** `storageState` is written, every dependent project inherits it.

`EPIC_PROXY_TOKEN` is unset outside a sandbox — local runs reach the dev server directly — so this is a no-op there.

Needs epic-build's matching change, which mints the token into `.env.test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Playwright specs failing in sandbox by crossing the `epic-proxy` gate before authentication. We visit `/?_proxy_token=...` once to set the `epic_proxy_auth` cookie, then proceed with sign-in; outside sandbox this is a no-op.

- **Migration**
  - Update `epic-build` to write `EPIC_PROXY_TOKEN` into `.env.test` so the harness receives the token.

<sup>Written for commit 07b178fb86a55907e97b0c34e5e198e17d139e32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/epic-new/epic-web/pull/45?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

