### PR TITLE
docs(skill): refresh the epic-cli skill

### DIFF
--- a/.agents/skills/epic-cli/SKILL.md
+++ b/.agents/skills/epic-cli/SKILL.md
@@ -1,15 +1,64 @@
 ---
 name: epic-cli
-description: Drive the Epic CLI (`epic`) — projects, PRDs, issues, and the agent build lifecycle (plan → execute → verify → fix → review → merge). Issue and PRD content lives in the Epic database and is reached through this CLI, never through files. Use when the user asks to create a project, write or break a PRD, create/plan/build/review/merge an issue, read what an issue or PRD says, or run a preview or worktree for one. Also covers the marketplace side — publishing an issue as a request, proposals, funded contracts, and Stripe payouts. Triggers on "create a project", "generate a PRD", "break the PRD into issues", "plan this issue", "build this issue", "what does issue X say", "open the PR for this issue", "link this repo to a project", "post this issue to the marketplace", "accept this proposal", "approve the contract", "set up payouts".
+description: Drive the Epic CLI (`epic`) — projects, PRDs, issues, and the agent build lifecycle (plan → execute → verify → fix → review → merge). Issue and PRD content lives in the Epic database and is reached through this CLI, never through files. Use when the user asks to create a project, write or break a PRD, create/plan/build/review/merge an issue, read what an issue or PRD says, run a preview or worktree for one, or set up the machine to build at all. Also covers the marketplace side — publishing an issue as a request, proposals, funded contracts, and Stripe payouts. Triggers on "create a project", "generate a PRD", "break the PRD into issues", "plan this issue", "build this issue", "what does issue X say", "open the PR for this issue", "link this repo to a project", "why won't my build start", "connect Claude", "set up the agent credential", "post this issue to the marketplace", "accept this proposal", "approve the contract", "set up payouts".
 ---
 
 # Epic CLI
 
-`epic` drives a project through PRD → issues → build. Three facts shape everything below:
+`epic` drives a project through PRD → issues → build. Four facts shape everything below:
 
 - **Content lives in the database.** An issue's body and a PRD's body are DB columns reached over the API. There are no `.epic/issues/*.md` or `.epic/prds/*.md` files — do not create them, do not look for them.
 - **The repo carries machine config only**: the gitignored `.epic/settings.local.json` (linked `projectId`, prefix) and `.epic/.worktreeinclude`. `.epic/sessions/` holds ephemeral per-phase scratch.
 - **Commands need a linked project.** Anything touching issues or PRDs fails with "this repo is not linked to a project" until `epic project link` has run in that repo.
+- **A build is local unless you ask for the cloud.** `--remote` (alias `--cloud`) is the only thing that sends a build to a sandbox. Nothing else — no project setting, no environment — makes that decision for you.
+
+## Setup, once — and `epic doctor` is how you check it
+
+```bash
+epic doctor          # every prerequisite, and the exact fix for each gap
+```
+
+Run it first when a build misbehaves. It checks this machine (`gh`, git), the Epic login, the lifecycle skills this repo needs, and — when the repo is linked — what a cloud build additionally requires: the GitHub app and the agent credential **on your account**. It only reports; it never fixes.
+
+Its exit code carries the verdict, so `epic doctor && epic issue build …` is safe: **a local gap exits 1** (nothing builds), a cloud-only gap exits **0** and says local builds are ready.
+
+The three things it will tell you to do:
+
+```bash
+epic login                    # authenticate (see the pty note below)
+epic skill install            # the workflow skills the build prompts follow
+epic credential login         # mint + store the token cloud builds authenticate with
+```
+
+`epic skill install` is not optional flavour. Each build phase hands the agent a prompt saying *follow the project's execute skill (`.claude/skills/execute/SKILL.md`)* — a path relative to the repo being built. In a repo without those files the agent finds nothing and improvises: the build still runs, just not the way it was designed to. Once per machine for `epic-cli`, once per repo for the lifecycle skills.
+
+## The agent credential: which build needs what
+
+The two build targets authenticate differently, and confusing them is the most common false alarm.
+
+| Build | Authenticates with | Set up by |
+|---|---|---|
+| local (default) | the `claude` **on this machine**, with whatever login it already has | `claude` itself — nothing to do in Epic |
+| `--remote` | a token stored on your **Epic account** | `epic credential login` |
+
+So a laptop with a perfectly good `claude` login and an empty account still cannot build in the cloud — and a missing account credential never blocks a local build.
+
+```bash
+epic credential login                  # mint + store + verify, in one step (needs a terminal)
+epic credential login --skip-mint      # you already have a token; just paste it
+epic credential status                 # what the account has, and whether it still works
+epic credential delete                 # erase it from the account
+
+claude setup-token                     # mint by hand; prints the token, saves it nowhere
+pbpaste | epic credential set          # store one you already have — piping keeps it out of history
+epic credential set --token sk-ant-oat01-…
+```
+
+`credential login` hands the terminal to `claude setup-token` (which opens a browser and blocks), then takes the paste and verifies it with Anthropic. **It needs a TTY** — an agent or a script cannot run it, and the CLI's own remedies know that: without a terminal they tell you to ask the user to mint with `claude setup-token` and then store it with `epic credential set --token <token>`. Do that, rather than blocking on an interactive command.
+
+That token is one-year and **inference-only** — it can run the agent and nothing else with the account. It belongs to the **account**, not to a repo, and a build authenticates as the project's owner wherever it runs.
+
+`epic credential status` asks Anthropic whether the token still works, and exits non-zero when the answer is no. Three answers, and they mean different things: connected, **rejected** (mint a new one), and **could not reach Anthropic** — which is a statement about the network, not about the token.
 
 ## Check the target before any write
 
@@ -34,7 +83,9 @@ It answers *where*, not *whether*: `whoami` reports the stored profile and **doe
 | Active agent sessions | `epic issue sessions` · `epic prd sessions` |
 | Agent transcript | `epic issue log <ID> [--session build\|verify\|merge]` |
 
-Anything that runs an agent (`build`, `plan`, `execute`, `verify`, `fix`, `review`, `generate`, `break`, `interview`) attaches a live viewer by default. Pass `-b` to detach and return immediately; without it, in a non-interactive context, the command holds the terminal.
+Anything that runs an agent (`build`, `plan`, `execute`, `verify`, `fix`, `review`, `generate`, `break`, `interview`) attaches a live viewer by default. Pass `-b` to detach and return immediately; without it, in a non-interactive context, the command holds the terminal. On the builds that take a viewer, `--no-tty` is the middle ground: it shows progress and exits when the build ends, instead of waiting for a `q` nobody will press.
+
+`attach` is the exception that cannot be worked around: `tmux attach` requires a controlling terminal, so **`epic issue attach` / `epic prd attach` refuse without a TTY** rather than starting an agent nothing can reach. To see what a session is doing from a script, use `sessions` and `log`.
 
 ### `epic login` has no `-b` — give it a pty
 
@@ -49,6 +100,16 @@ script -qec "epic login <profile> --url <backend-url>" /dev/null
 The output is a raw ANSI dump with the URL and the 8-character code among the escape
 sequences. It blocks polling until approved, so run it in the background.
 
+## Typos are refused, not absorbed
+
+Every `project`, `prd`, `issue`, `doctor` and `credential` subcommand declares the flags it
+accepts, and anything else **exits 1 naming what it does accept**. `--provider` is validated
+against the set that command allows (`claude`, `claude-headless`, `codex`, `opencode`; the PRD
+authoring commands take `claude|codex`), and a value-taking flag left without a value
+(`--status`, `--base`, `--token`, `--limit`) is an error rather than "absent". So a mistyped
+flag never runs a whole build on a different agent, or a different operation than the one
+typed.
+
 ## Create and link
 
 ```bash
@@ -57,14 +118,21 @@ epic project list                      # ID / STATUS / PREFIX / NAME / DATE
 epic project link <8-char-id-or-exact-name>   # link an existing repo; --force skips the origin check
 ```
 
-`--web` scaffolds from the epic-web template and is the type the build lifecycle expects; `--terminal` and `--empty` exist for other shapes. `--online` also provisions a cloud sandbox.
+`epic project` is lifecycle only — `new`, `list`, `link`. **Nothing under `project` runs an
+agent or builds.** Issues are built through the PRD that owns them (`epic prd build <PRD-ID>`,
+which stacks them on the `prd-<n>` integration branch and opens one PR) or one at a time
+(`epic issue build <ID>`).
+
+`--web` scaffolds from the epic-web template and is the type the build lifecycle expects;
+`--terminal` and `--empty` exist for other shapes. Projects register as **local**; `--remote`
+(alias `--cloud`) also provisions a sandbox and registers a cloud project.
 
 Three things `project new` does that are easy to be surprised by: the name **cannot contain
-spaces** (`todo-app`, not "Todo App"), it **creates a real repository in the user's GitHub
-account** through `gh`, and it registers the project on the backend the active profile points
-at. Confirm the name and the target before running it. `project link` refuses a repo whose
-git origin does not match the project's repo — `--force` links anyway and records that it was
-forced.
+spaces** (`todo-app` or `org/todo-app`, not "Todo App" — extra positionals are refused), it
+**creates a real repository in the user's GitHub account**, and it registers the project on the
+backend the active profile points at. Confirm the name and the target before running it.
+`project link` refuses a repo whose git origin does not match the project's repo — `--force`
+links anyway and records that it was forced.
 
 ## PRD → issues
 
@@ -74,15 +142,27 @@ epic prd show PRD-1                                             # read what it w
 epic prd plan PRD-1 -b                                          # rewrite the body as a structured spec
 epic prd break PRD-1 -b                                         # decompose into issues, in dependency order
 epic issue list -b                                              # the issues it created
+epic prd build PRD-1                                            # build them onto prd-1, in order
+epic prd approve PRD-1                                          # merge prd-1 -> main, PRD done
 ```
 
-`break` writes each issue through the API with its `dependsOn` edges, so `epic project build` can walk them in order. `--replace` redoes a breakdown, deleting its untouched issues first. A finished breakdown settles the PRD on `ready` — decomposed, nothing running — whichever client ran it. `building` means a build actually started (`prd build` sets it).
+`break` writes each issue through the API with its `dependsOn` edges, so `prd build` can walk
+them in order. `--replace` redoes a breakdown, deleting its untouched issues first, and is
+refused if any of them has started. A finished breakdown settles the PRD on `ready` —
+decomposed, nothing running; `building` means a build actually started.
+
+`epic prd approve` is the landing, not a check: it merges the `prd-<n> → main` pull request,
+stamps the PRD `done`, deletes the integration branch and points the project sandbox at the new
+main. It is valid only from `in_review` (every issue done), and the server owns that gate.
+
+**Two different `--local` flags, on purpose.** On `prd build` it means *where the build runs*.
+On `prd generate` / `prd break` it means *do not touch the backend at all* — offline authoring.
 
 ## One issue, end to end
 
 ```bash
 epic issue new "Add a todo list page"    # title only; prints the identifier
-epic issue build TOD-3 --local -b        # plan → execute → verify → fix, on this machine
+epic issue build TOD-3 -b                # plan → execute → verify → fix, on this machine
 epic issue log TOD-3                     # what the agent did
 epic issue pr TOD-3                      # push the branch, open the PR
 epic issue approve TOD-3                 # merge and mark Done
@@ -90,12 +170,19 @@ epic issue approve TOD-3                 # merge and mark Done
 
 `epic issue new` takes a **title only** — there is no flag for the body. The body is authored by a build phase, by `epic issue interview <ID>`, or in the web app.
 
-`--local` runs the worktree and agent here; `--remote` posts a cloud build (add `--foreground` to poll it to completion). `--mode manual` (the default) stops at In Review for `epic issue approve`; `--mode auto` self-merges each issue. Individual phases run standalone: `epic issue plan|execute|verify|fix|review <ID> -b`.
+**Two independent axes, and they are not alternatives to each other.** Local vs `--remote` is
+*where* the build runs; `--mode auto|manual` is *how it finishes*. `--mode manual` (the default)
+stops at In Review for `epic issue approve`; `--mode auto` self-merges each issue. Individual
+phases run standalone: `epic issue plan|execute|verify|fix|review <ID> -b`.
 
 A remote build only works against a **publicly reachable backend**. The CLI inside the cloud
 sandbox is pointed at the app's own base URL, so a backend on `localhost` is the sandbox's
 loopback, not yours: the sandbox provisions and then the build dies on its first call home.
-Use `--local` against a local backend, and keep `--remote` for staging or production.
+Build locally against a local backend, and keep `--remote` for staging or production.
+
+`--record` films each scenario during every verify attempt, one video per acceptance
+criterion, and the review page plays them back. Off by default because filming slows the
+phase — turn it on when the question is *why did verify think this passed*.
 
 `epic issue log` reads a **local** build's transcript from disk. A remote build's transcript
 lives in the web app, not on this machine.
@@ -107,6 +194,16 @@ Each phase fetches the issue body from the API into a scratch buffer, hands the 
 - Edit the file the prompt names. Never invent a path, never write under `.epic/issues/` or `.epic/prds/`, and never assume the file survives the run.
 - While a build is active the content is locked to that build's grant. A write from anywhere else gets `409 ISSUE_LOCKED_BUILDING` — the answer is to wait or stop the build, not to retry harder.
 - A stuck job self-heals: a build whose state has not moved for 30 minutes releases the lock on the next write.
+
+## Stopping the right thing
+
+`epic issue stop` and `epic prd stop` end a **local** tmux session and settle its sidecar — this
+is the fix for "session in progress" when nothing is running. `prd stop` also returns a PRD
+frozen in `generating` or `breaking` to `draft`, which is the state the command exists to
+rescue; a PRD in `building` is left alone, because that status belongs to the issue build queue.
+
+A cloud build has no session on this machine, and there is **no CLI command that stops one** —
+stop it from the web app.
 
 ## Marketplace: an issue, a proposal, a paid contract
 
@@ -149,16 +246,26 @@ profile, usually via `epic --as <admin-profile>`.
 
 | Symptom | What it means | Do this |
 |---|---|---|
+| Anything about a build, before guessing | — | `epic doctor` |
 | A list command printed nothing | TUI with no terminal | Re-run with `-b` |
+| A cloud build is refused for a missing agent credential | The account has no token; the machine's `claude` login is a different thing | `epic credential login` — or, with no TTY, have the user run `claude setup-token` and store it with `epic credential set --token …` |
+| A cloud build authenticates, then the agent fails on auth | The stored token was revoked | `epic credential status` to confirm, then mint and set a new one |
 | "session in progress" but nothing is running | Sidecar outlived its tmux session | `epic issue stop <ID>` / `epic prd stop <ID>`, then re-run |
+| A PRD sits in `generating` / `breaking` forever | Its agent was killed, so the settle hook never ran | `epic prd stop <PRD-ID>` — it reverts the status to `draft` |
+| Nothing here stops a cloud build | `issue stop` / `prd stop` are local-session commands | Stop it from the web app |
 | `409 ISSUE_LOCKED_BUILDING` | A build owns the content | `epic issue sessions`; wait, or stop the build |
 | "not linked to a project" | No `projectId` in this repo | `epic project link <ref>` |
-| "Your session has expired" | Token is stale | `epic login` — under a pty, see above |
+| `epic project build` is not a command | Project-level building does not exist | `epic prd build <PRD-ID>`, or `epic issue build <ID>` |
+| "Your session has expired" | Epic token is stale (not the agent's) | `epic login` — under a pty, see above |
 | `epic login` printed nothing and exited 1 | TUI device flow with no terminal, and there is no `-b` | Re-run under a pty: `script -qec "epic login …" /dev/null` |
 | `whoami` looks healthy but every command says the session expired | `whoami` reads the stored profile without validating the token | Trust `epic project list`, not `whoami`, then `epic login` |
 | A write landed somewhere unexpected | Wrong profile | `epic whoami` before writes |
-| A detached (`-b`) agent vanished right after starting | Its tmux server was a child of the shell that launched it and died with it | Launch it detached from the process group: `setsid epic issue build <ID> --local -b` |
-| A remote build starts, then fails on its first call home | The sandbox cannot reach a `localhost` backend | Build `--local`, or point at a publicly reachable backend |
+| `attach` refuses with "needs a terminal" | tmux cannot take over a non-TTY stdin | Use `sessions` / `log`, or attach from an interactive shell |
+| "unknown flag(s) for …" | The subcommand does not accept it | Use one of the accepted flags it names |
+| A detached (`-b`) build printed the reason it died | The parent watches for an early exit and quotes the log | Fix what the quoted log says, then re-run |
+| A detached (`-b`) agent vanished right after starting | Its tmux server was a child of the shell that launched it and died with it | Launch it detached from the process group: `setsid epic issue build <ID> -b` |
+| A remote build starts, then fails on its first call home | The sandbox cannot reach a `localhost` backend | Build locally, or point at a publicly reachable backend |
+| The agent ignored the plan/execute/verify workflow | The repo has no lifecycle skills for the prompt to name | `epic skill install --project` |
 
 Content that was already PATCHed is safe in the database; a phase that dies mid-flight leaves
 its buffer on disk and settles on the next foreground run of that phase.

--- a/.agents/skills/epic-cli/references/commands.md
+++ b/.agents/skills/epic-cli/references/commands.md
@@ -7,59 +7,77 @@ Conventions used below:
 
 - `-b` — plain text instead of the TUI on read commands; detach instead of attaching a
   viewer on agent commands.
-- `--provider claude|codex|opencode` — which agent runs the phase (PRD commands accept
-  `claude|codex`). Defaults to the project's agent, read from the API.
+- `--provider claude|claude-headless|codex|opencode` — which agent runs the phase (the PRD
+  authoring commands accept `claude|codex`). Defaults to the project's agent, read from the
+  API. An unknown value, or the flag with no value, is an error naming the accepted set.
 - `--model NAME` — override the Claude model for every agent in the run.
 - `<ID>` — an issue identifier (`TOD-3`), its sequence number (`3`), or its raw id.
   `<PRD-ID>` — `PRD-1`, `1`, or the uuid.
+- Every subcommand below rejects flags it does not accept (exit 1, naming the accepted set),
+  and refuses a value-taking flag left without a value.
 
 ## project
 
+Lifecycle only — nothing here runs an agent or builds. Building goes through
+`epic prd build <PRD-ID>` (the fan-out, one PR per PRD) or `epic issue build <ID>` (one issue).
+
 | Command | Notes |
 |---|---|
-| `epic project new [name] [--web\|--terminal\|--empty] [--codex\|--opencode] [--online]` | Name takes no spaces. Offline by default: scaffold + a repo in the user's GitHub account + registration. `--online` also provisions a sandbox. No name → interactive wizard. |
-| `epic project list [--owned\|--team] [--limit N] [--cursor C]` | Columns: ID (8 chars) / STATUS / PREFIX / NAME / DATE. `link` accepts the 8-char ID shown here, or the exact NAME — not the PREFIX. |
+| `epic project new [name] [--web\|--terminal\|--empty] [--codex\|--opencode] [--remote\|--cloud]` | Name takes no spaces; `org/repo-name` is accepted, extra positionals are refused. Local by default: scaffold + a repo in the user's GitHub account + registration. `--remote` also provisions a sandbox and registers a cloud project. No name → interactive wizard. |
+| `epic project list [--owned\|--team] [--limit N] [--cursor C]` | Columns: ID (8 chars) / STATUS / PREFIX / NAME / DATE. `link` accepts the 8-char ID shown here, or the exact NAME — not the PREFIX. `--limit` must be a positive integer. |
 | `epic project link [ref] [--force]` | Links this repo to a project and writes `.epic/settings.local.json` (+ the `.epic` gitignore entries). No ref prints the current link. `--force` links even when the git origin does not match the project's repo. |
-| `epic project build [--local\|--remote] [--mode auto\|manual] [--clean] [--foreground] [--no-tty]` | Builds every issue in dependency order, in parallel up to `maxParallelIssues`. |
 
 ## issue
 
 | Command | Notes |
 |---|---|
-| `epic issue new [title] [--verbose]` | Title only — the body is authored later. No title → interactive wizard. Prints the identifier the backend assigned. (`--no-sync` still appears in the help but is ignored; creation always goes through the API.) |
+| `epic issue new [title] [--verbose]` | Title only — the body is authored later. No title → interactive wizard. Prints the identifier the backend assigned. Creation always goes through the API. |
 | `epic issue list [status] [-b]` | Optional status filter. **Prints nothing without `-b`** when there is no TTY. |
 | `epic issue show <ID> [-b]` | Metadata then the body. |
-| `epic issue build <ID> [--local\|--remote] [-b] [--foreground] [--mode auto\|manual] [--base BRANCH] [--model NAME] [--provider P]` | plan → execute → verify → fix loop. Target defaults to the project's mode. `--base` cuts the worktree from another branch. `--foreground` applies to remote builds (poll to completion). |
-| `epic issue plan\|execute\|verify\|fix\|review <ID> [-b] [--provider P] [--model NAME]` | Individual phases. `verify` also takes `-p PORT` (default 3000). |
+| `epic issue build <ID> [--local\|--remote] [-b] [--foreground] [--no-tty] [--mode auto\|manual] [--base BRANCH] [--model NAME] [--provider P] [--record]` | plan → execute → verify → fix loop. **Local unless `--remote` (alias `--cloud`)** — no project setting decides this, and the resolution is offline. `--base` cuts the worktree from another branch. `--foreground` applies to remote builds (poll to completion). `--no-tty` exits the viewer when the build ends instead of waiting for `q`. A `-b` build that dies right after detaching is reported with its log, not as success. |
+| `epic issue plan\|execute\|verify\|fix\|review <ID> [-b] [--provider P] [--model NAME]` | Individual phases. `verify` also takes `-p PORT` (default 3000) and `--record` (one video per scenario; off by default because it slows the phase). |
 | `epic issue interview <ID> [--provider P]` | Q&A that rewrites the issue body. |
 | `epic issue pr <ID>` | Push the worktree branch and open (or surface) its PR. |
 | `epic issue merge <ID>` · `epic issue approve <ID>` | Agent-driven merge into main; `approve` also sets the issue Done. |
 | `epic issue close <ID>` · `epic issue assign <ID> <user>` | Status/assignee changes. |
 | `epic issue worktree <ID>` · `epic issue run <ID> -- <cmd>` | Create the worktree; run a command with its cwd set to that worktree (exit code propagates). |
-| `epic issue attach <ID>` · `epic issue message <ID> "<text>" [--session build\|verify\|merge] [-b]` | Attach to a live agent session; send it a message (resumes it). |
+| `epic issue attach <ID>` · `epic issue message <ID> "<text>" [--session build\|verify\|merge] [-b]` | Attach to a live agent session; send it a message (resumes it). `attach` requires a TTY and refuses without one, before anything is spent. |
 | `epic issue log <ID> [--session build\|verify\|merge]` | Reads the transcript from disk, so it works after the session ends. Local builds only — remote transcripts live in the web app. |
-| `epic issue sessions` · `epic issue stop <ID>` | List tmux-backed sessions; end one and reconcile its sidecar (this is the fix for a stale "session in progress"). |
-| `epic issue start <ID> [--foreground] [--model NAME]` | Shorthand for a remote build. |
+| `epic issue sessions` · `epic issue stop <ID>` | List tmux-backed sessions; end one and settle its sidecar (this is the fix for a stale "session in progress"). Local only — no CLI command stops a cloud build; use the web app. |
+| `epic issue start <ID> [--foreground] [--model NAME]` | Alias of `build --remote`, retained for compatibility. Prefer `build --remote`. |
 
 ## prd
 
 | Command | Notes |
 |---|---|
-| `epic prd new [title] [--interview\|--generate] [--verbose]` | Creates the PRD record. The flags skip the wizard's mode picker. |
-| `epic prd generate [PRD-ID\|description] [-b] [--provider claude\|codex]` | Authors the body with an agent — from a description (creates a draft) or from an existing PRD's body. |
+| `epic prd new [title] [--interview\|--generate] [--provider P] [-b] [--verbose]` | Creates the PRD record. `--generate` / `--interview` continue straight into that command on the PRD just created (with no title, they skip the wizard's mode picker); `--provider` and `-b` pass through. |
+| `epic prd generate [PRD-ID\|description] [-b] [--local] [--provider claude\|codex]` | Authors the body with an agent — from a description (creates a draft) or from an existing PRD's body. `--local` here means offline authoring (no backend), not a build target. |
 | `epic prd show <PRD-ID> [-b]` | Prints identifier, status and the body verbatim. |
 | `epic prd list [--status draft\|generating\|breaking\|ready\|building\|in_review\|done\|archived] [--refresh] [-b]` | **Prints nothing without `-b`** when there is no TTY. `ready` = decomposed, nothing running; `building` = a build actually started. |
 | `epic prd plan <PRD-ID> [-b] [--provider P]` | Rewrites the body as a structured spec. |
 | `epic prd interview <PRD-ID> [--provider P]` | Q&A that rewrites the body. |
-| `epic prd break <PRD-ID> [-b] [--replace] [--provider P]` | Decomposes into issues, created through the API in dependency order with their `dependsOn` edges. `--replace` deletes the previous breakdown's untouched issues first and is refused if any have started. On success the PRD settles on `ready`. |
-| `epic prd build <PRD-ID> [--local\|--remote] [-b] [--mode auto\|manual] [--foreground] [--no-tty]` | Builds the PRD's issues, stacking them onto a `prd-<n>` branch. |
-| `epic prd approve <PRD-ID> [--squash]` | Linked repo: readiness check. Local repo: merges the integration PR and sets the PRD done. |
-| `epic prd attach <PRD-ID>` · `epic prd stop <PRD-ID>` · `epic prd sessions` | Session control, same shape as the issue commands. |
+| `epic prd break <PRD-ID> [-b] [--replace] [--local] [--provider P]` | Decomposes into issues, created through the API in dependency order with their `dependsOn` edges. `--replace` deletes the previous breakdown's untouched issues first (addressed by row id) and is refused if any have started. On success the PRD settles on `ready`. `--local` = offline authoring. |
+| `epic prd build <PRD-ID> [--local\|--remote] [-b] [--mode auto\|manual] [--foreground] [--no-tty] [--record]` | Builds the PRD's issues in dependency order, stacking them onto the `prd-<n>` branch. Local unless `--remote` (alias `--cloud`). |
+| `epic prd approve <PRD-ID>` | Lands the PRD: merges its `prd-<n> → main` PR, sets the status `done`, deletes the integration branch and points the sandbox at the new main. Valid only from `in_review`; idempotent once done. `--squash` is refused with the reason (the PRD PR lands as a merge commit). |
+| `epic prd attach <PRD-ID>` · `epic prd sessions` | Session control, same shape as the issue commands. `attach` lazily starts the PRD's agent — but only on a TTY, which it checks first. |
+| `epic prd stop <PRD-ID>` | Ends the session and settles the sidecar, **and** reverts a PRD stuck in `generating` / `breaking` back to `draft`. `building` is left alone (it belongs to the issue build queue). |
 
-## auth and profiles
+## setup, auth and profiles
+
+Two different credentials, and mixing them up is the usual confusion. The **Epic** login
+(`epic login`) is who you are to the backend. The **agent** credential (`epic credential`) is
+what a cloud build authenticates to Anthropic with. A local build uses neither — it runs the
+`claude` on this machine with whatever login that already has.
 
 | Command | Notes |
 |---|---|
+| `epic doctor` | Every prerequisite for a build — machine, Epic login, agent credential, this repo's lifecycle skills, and (when linked) the cloud-build requirements — with the fix for each gap. Reports only; never writes. **Exits 1 on a local gap** (nothing builds); a cloud-only gap exits 0 and says local builds are ready. |
+| `epic skill install [<name>…] [--user\|--project] [--type web\|terminal] [--check] [--force] [--prune] [-y]` | Installs the skills the build prompts name by relative path. Without them the agent improvises. `--check` exits 1 if anything is missing or stale (CI). Hand-edited skills are reported and skipped unless `--force`. |
+| `epic skill list` | Every bundled skill and its status at both targets. Never writes. |
+| `epic credential login [--skip-mint]` | Mint and store in one step: hands the terminal to `claude setup-token`, takes the paste, verifies it with Anthropic. **Needs a TTY** — `setup-token` opens a browser and blocks, so a script or an agent cannot use this. `--skip-mint` when the token was minted elsewhere. |
+| `epic credential set [--token <tok>]` | Stores a token you already have — the non-interactive door. With no `--token` it reads stdin: prefer `pbpaste \| epic credential set`, since an argument lands in shell history and `ps`. `--token` without a value is refused rather than falling through to stdin. |
+| `epic credential status [--no-verify]` | What the **account** has on file, and whether Anthropic still accepts it. Reports the last 4 characters of the token, never the token. `--no-verify` skips the round trip. Exits non-zero when the token is rejected. |
+| `epic credential delete` | Erases the token from the account. Does not revoke it at Anthropic — do that there if you need it dead everywhere. |
 | `epic whoami` | `Name (email) — role` then `profile → URL`. |
 | `epic login [name] [--url URL] [--rebind]` | Browser device-auth flow; the profile name defaults to a slug of the URL. |
 | `epic logout [--purge]` | Blanks the token, or deletes the profile with `--purge`. |
@@ -67,7 +85,7 @@ Conventions used below:
 | `epic profile switch [name]` · `epic profile show [name]` · `epic profile add <name> [--url URL]` · `epic profile set-url <name> <url>` · `epic profile rename <old> <new>` · `epic profile remove <name>` | Profile management. `switch` with no argument needs a terminal. |
 | `epic --as <profile> <command>` | One-off profile override for a single command. |
 
-Precedence when resolving credentials: `EPIC_OAUTH_TOKEN` (baseUrl = `EPIC_API_URL` if set, **otherwise production**) → the pair `EPIC_API_URL` + `EPIC_ACCESS_TOKEN` → the active profile. Setting only one half of the pair is ignored with a warning.
+Precedence when resolving the **Epic** credential (not the agent one): `EPIC_OAUTH_TOKEN` (baseUrl = `EPIC_API_URL` if set, **otherwise production**) → the pair `EPIC_API_URL` + `EPIC_ACCESS_TOKEN` → the active profile. Setting only one half of the pair is ignored with a warning.
 
 ## worktrees, previews, design, debugger
 
@@ -145,5 +163,12 @@ USD is the only currency the marketplace supports today.
 | `this repo is not linked to a project` | Run `epic project link <ref>`. |
 | `session in progress; use 'epic <kind> attach' ... or 'stop' ...` | A sidecar outlived its tmux session. `epic issue stop <ID>` / `epic prd stop <ID>` clears it. |
 | `Your session has expired` | `epic login`. |
+| `unknown flag(s) for '<cmd> <sub>'` | The flag is a typo or belongs to another subcommand; the message lists what this one accepts. |
+| `--provider must be one of: …` | An unknown or empty `--provider`. It is refused instead of falling back to the default agent. |
+| `attach needs a terminal — stdin is not a TTY` | `attach` cannot hand the terminal to tmux. Use `sessions` / `log`, or run it from an interactive shell. |
 | `Cannot reach <url>` | The backend is down or the profile points somewhere unreachable — check `epic whoami`. |
-| `GITHUB_CONNECTION_REQUIRED` / `DEFAULT_BRANCH_MUST_BE_MAIN` | Cloud-build preconditions: connect GitHub in Settings → Integrations; the repo's default branch must be `main`. |
+| `REMOTE_REQUIRES_AGENT_PROVIDER` | The account has no agent credential. `epic credential login` at a terminal; otherwise have the user run `claude setup-token` and store it with `epic credential set --token …`. A working `claude` on this machine does not count — that one is for local builds. |
+| `AGENT_CREDENTIAL_MISSING` / `AGENT_CREDENTIAL_REVOKED` | Same fix, found later: the build's own pre-flight. Confirm with `epic credential status`. |
+| `REMOTE_REQUIRES_GITHUB_APP` / `GITHUB_CONNECTION_REQUIRED` | Cloud builds push through the Epic GitHub App, so it must be installed on the repo's owner — the error carries the install URL. |
+| `DEFAULT_BRANCH_MUST_BE_MAIN` | Cloud-build precondition: the repo's default branch must be `main`. |
+| `SNAPSHOT_OUTDATED` | The cloud sandbox ships an older `epic` than the backend requires. Not fixable from here — the snapshot has to be rebuilt. |


### PR DESCRIPTION
Refresh of the `epic-cli` skill so it describes the CLI as it behaves today.

What the skill now states:

- **Target** — a build is local unless `--remote` (alias `--cloud`); resolution is offline and no project setting decides it.
- **`epic project`** — lifecycle only (`new`/`list`/`link`). Building goes through `epic prd build <PRD-ID>` or `epic issue build <ID>`. `project new` is local by default and takes `--remote`.
- **`epic prd approve`** — lands the PRD (merges `prd-N → main`, status `done`), valid only from `in_review`.
- **`epic prd stop`** — also reverts a PRD stuck in `generating`/`breaking` to `draft`.
- **Credential** — `epic credential login` mints + stores + verifies (needs a TTY); without one, `claude setup-token` by the user then `epic credential set --token`.
- **`epic doctor`** — exits 1 on a local gap, 0 on a cloud-only gap.
- **Strict input** — unknown flags and unknown/empty `--provider` are refused per subcommand; `attach` requires a TTY.
- Stopping a cloud build has no CLI command — it is done from the web app.

`references/commands.md` updated to match across project / issue / prd / credential, plus new error rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the `epic-cli` skill docs and command reference to match current CLI behavior, with clearer build targets, credentials, and session handling. Updates tighten flag validation and explain TTY requirements and `doctor` outcomes.

- **Refactors**
  - Builds are local by default; use `--remote`/`--cloud` for cloud. Target resolution is offline.
  - `epic project` is lifecycle only (`new`/`list`/`link`); build via `epic prd build <PRD-ID>` or `epic issue build <ID>`. `project new` now supports `--remote`.
  - PRD flow: `epic prd approve` lands `prd-<n> → main` and sets `done`; `epic prd stop` unsticks `generating`/`breaking` to `draft`. No CLI to stop cloud builds (use web app).
  - Credentials: `epic credential login` mints + stores + verifies (needs a TTY). Non-interactive path: `claude setup-token` then `epic credential set --token`. Local builds use the machine’s `claude`; cloud builds use the account token.
  - `epic doctor` reports prerequisites and fixes; exits 1 on local gaps, 0 on cloud-only gaps.
  - Strict input: unknown flags and unknown/empty `--provider` are rejected; value-less flags error. `attach` requires a TTY. Viewer supports `--no-tty`; detached builds surface early failures.
  - Docs synced across project/issue/prd/credential; added `--record`, provider options, error rows, and notes like `issue start` aliasing `build --remote`.

<sup>Written for commit 09aa437af1eeb02d798b65b9cabda9d8b94776f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/epic-new/epic-web/pull/46?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

