### PR TITLE
docs(skill): reconcile the epic skill

### DIFF
--- a/.agents/skills/epic/SKILL.md
+++ b/.agents/skills/epic/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: epic
-description: Drive the Epic CLI (`epic`) — projects, PRDs, issues, and the agent build lifecycle (plan → execute → verify → fix → review → merge). Issue and PRD content lives in the Epic database and is reached through this CLI, never through files. Use when the user asks to create a project, write or break a PRD, register a PRD they already have, create/plan/build/review/merge an issue, read what an issue or PRD says, run a preview or worktree for one, or set up the machine to build at all. Also covers the marketplace side — publishing an issue as a request, proposals, funded contracts, and Stripe payouts. Triggers on "create a project", "generate a PRD", "here is my PRD", "import this PRD", "I already have the PRD", a pasted product spec to turn into issues, "break the PRD into issues", "plan this issue", "build this issue", "what does issue X say", "open the PR for this issue", "link this repo to a project", "why won't my build start", "connect Claude", "set up the agent credential", "post this issue to the marketplace", "accept this proposal", "approve the contract", "set up payouts".
+description: Drive the Epic CLI (`epic`) — projects, PRDs, issues, prototypes, and the agent build lifecycle (plan → execute → verify → fix → review → merge). Issue, PRD and prototype content lives in the Epic database and is reached through this CLI, never through files. Use when the user asks to create a project, write or break a PRD, register a PRD they already have, create/plan/build/review/merge an issue, turn a PRD into a prototype and build its screens, read what an issue or PRD says, run a preview or worktree for one, or set up the machine to build at all. Also covers the marketplace side — publishing an issue as a request, proposals, funded contracts, and Stripe payouts. Triggers on "create a project", "generate a PRD", "here is my PRD", "import this PRD", "I already have the PRD", a pasted product spec to turn into issues, "break the PRD into issues", "plan this issue", "build this issue", "what does issue X say", "open the PR for this issue", "link this repo to a project", "why won't my build start", "connect Claude", "set up the agent credential", "prototype this PRD", "build the prototype", "build this screen", "what screens does the prototype have", "stop the prototype build", "post this issue to the marketplace", "accept this proposal", "approve the contract", "set up payouts".
 ---
 
 # Epic CLI
@@ -8,7 +8,7 @@ description: Drive the Epic CLI (`epic`) — projects, PRDs, issues, and the age
 `epic` drives a project through PRD → issues → build. Four facts shape everything below:
 
 - **Content lives in the database.** An issue's body and a PRD's body are DB columns reached over the API. There are no `.epic/issues/*.md` or `.epic/prds/*.md` files — do not create them, do not look for them.
-- **The repo carries machine config only**: the gitignored `.epic/settings.local.json` (linked `projectId`, prefix) and `.epic/.worktreeinclude`. `.epic/sessions/` holds ephemeral per-phase scratch.
+- **The repo carries machine config only**: the gitignored `.epic/settings.local.json` (linked `projectId`, prefix) and `.epic/.worktreeinclude`. `.epic/sessions/<ID>/` holds a run's state — the phase marker (`build.json`, self-healing) and the agent's conversation id, which `stop` clears. It is not content.
 - **Commands need a linked project.** Anything touching issues or PRDs fails with "this repo is not linked to a project" until `epic project link` has run in that repo.
 - **A build is local unless you ask for the cloud.** `--remote` (alias `--cloud`) is the only thing that sends a build to a sandbox. Nothing else — no project setting, no environment — makes that decision for you.
 
@@ -188,6 +188,92 @@ backticks and quotes; an unquoted heredoc expands `$DATABASE_URL` to nothing and
 what is inside backticks, corrupting the document silently. If you must use a heredoc, quote the
 delimiter (`<<'EOF'`).
 
+## PRD → prototype → screens
+
+A **prototype** is the other thing a PRD can become: a database-backed record holding an
+ordered plan of **screens**, each built and verified by an agent. It is not the folder
+scaffolder this command used to be — it writes no files, and there is no local workspace, no
+worktree and no tmux session. **The work always happens in a sandbox Epic provisions**, so
+unlike `issue build` there is no `--local`, and the account's agent credential is never
+optional.
+
+```bash
+epic prototype new PRD-3              # one planning turn: the PRD becomes an ordered screen plan
+epic prototype screens PROTO-3        # PATH  POSITION  STATUS  NAME  LAST FAILURE
+epic prototype build PROTO-3          # build every screen not yet completed, in dependency order
+epic prototype build PROTO-3 --detached --concurrency=2   # let Epic Build run it, two screens at a time
+epic screen build PROTO-3 /checkout   # or exactly one screen
+epic prototype stop PROTO-3           # end whatever run is in flight
+epic prototype list -b                # PROTO-n, title, status, source PRD, screen counts
+```
+
+A screen has **no minted identifier** — its `path` is unique within its prototype, so a screen
+is addressed as `<prototype-ref> <path>` (`PROTO-3 /checkout`). The raw uuid is accepted
+everywhere too; it is just not what the tables print.
+
+### Planning is a turn that must produce a plan
+
+`epic prototype new <prd-ref>` creates the prototype, opens one agent turn, follows it to
+settlement and prints the plan. Two consequences:
+
+- **Re-running reattaches.** The idempotency key is `(project, PRD)`, so Ctrl-C and a re-run
+  land on the same prototype and the same turn — Ctrl-C detaches this terminal, it does not
+  stop anything. `--new` is the explicit way to create a *second* prototype from the same PRD.
+- **A settled turn with zero screens is a failure**, not an empty plan: registering screens is
+  advisory for the agent, so the command refuses that outcome and tells you to re-run.
+
+### Building: a queue, and how many screens at once
+
+`epic prototype build` is attached by default — this CLI owns the queue and invokes the very
+same per-screen build `epic screen build` runs, **one screen at a time**, from your terminal,
+in dependency order and then by position. `--detached` hands the whole plan to Epic Build's
+durable workflow, which builds **several screens at once**, and returns the run identifiers
+instead.
+
+How many is not a setting: the build measures the machine it runs on — memory and cores — and
+derives a number from it. `--concurrency=N` asks for *fewer* (`--detached` only, refused
+otherwise), which is what you want when you are watching a build to see what it does, or when
+the machine has other work on it. Asking for more than the machine can carry is not an error
+and changes nothing: only the server knows how big the machine is, so the request is clamped
+where it can be measured.
+
+Each screen builds in a `git worktree` of its own, on its own dev server, and its work is
+merged into the prototype's checkout when it completes — which is why parallel screens do not
+overwrite each other. When two screens do change the same lines, the second one's merge
+conflicts, and the agent that wrote it resolves the markers in its own worktree on the next
+turn.
+
+- **A failure poisons only its dependents.** Independent screens keep building; anything whose
+  dependency can never complete settles as `blocked`.
+- **Exit code is non-zero only when a screen failed.** A blocked plan exits 0 — that is a
+  decision needing a person, not a crash.
+- `--rebuild` re-runs screens that already completed; without it they are skipped, and a plan
+  where everything is built is refused (`PROTOTYPE_HAS_NOTHING_TO_BUILD`) rather than reported
+  as a build over zero work. A **failed or blocked** screen retries without the flag.
+- A prototype runs **one build at a time**: a second `prototype build` while one is live is
+  refused `PROTOTYPE_BUSY`, and there is no local lock because there is no local process.
+  Within a build, the screens are what run in parallel.
+
+### Stopping is a command, not a Ctrl-C
+
+Every turn is durable and runs on Epic, so killing the CLI ends only this terminal's view.
+`epic prototype stop <ref>` writes the stop on the backend and returns — it kills no process,
+covers a full build and a single screen build alike (there is no `epic screen stop`), and
+exits 0 even when nothing was running, which is also how a stale `building` is cleared. The
+build queue notices between screens: any status other than `building` ends it. Resume with
+`epic prototype build <ref>`, which skips what is already completed.
+
+### Vocabulary
+
+| | Statuses |
+|---|---|
+| prototype | `draft` `planned` `building` `ready` `failed` `blocked` `archived` |
+| screen | `pending` `in_progress` `completed` `failed` `blocked` |
+
+`screens` and `stop` are plain text always. `list` is a TUI — pass `-b` off a terminal, or it
+prints nothing. `new` and `build` attach a viewer; `build --detached` is the way to return
+immediately (there is no `-b` on either).
+
 ## One issue, end to end
 
 ```bash
@@ -214,8 +300,9 @@ Build locally against a local backend, and keep `--remote` for staging or produc
 criterion, and the review page plays them back. Off by default because filming slows the
 phase — turn it on when the question is *why did verify think this passed*.
 
-`epic issue log` reads a **local** build's transcript from disk. A remote build's transcript
-lives in the web app, not on this machine.
+`epic issue log` reads a **local** build's transcript from disk. A remote build's
+conversation is not retained anywhere — what the web app keeps is the phases and outcomes,
+plus the verify phase's own trace on the review page.
 
 ## The content contract during a phase
 
@@ -234,6 +321,39 @@ rescue; a PRD in `building` is left alone, because that status belongs to the is
 
 A cloud build has no session on this machine, and there is **no CLI command that stops one** —
 stop it from the web app.
+
+### `stop` ends the run and keeps the work
+
+It is not an undo, and not a cleanup. It kills tmux, clears the backend's `building` flag
+(releasing the content lock), requeues an issue that was still in flight to **Queued**, and drops
+the agent's stored conversation so the next build starts a fresh one — the run is over, and the
+next build starts at plan.
+
+**It never removes the worktree or the branch, and there is no flag that makes it.** Two reasons,
+and they are worth knowing before you go looking for one:
+
+- Every command that *does* remove a worktree acts on a terminal decision — `merge` releases it
+  once the work landed (keeping the branch), `close` force-removes it and deletes the branch
+  because the issue is abandoned. `stop` writes `Queued`, which is the opposite.
+- The worktree is what makes the next build cheap: `createWorktree` reuses it instead of
+  re-copying `node_modules` and re-seeding the database.
+
+So `stop` reports instead of deleting, and the report is the part to read out to the user:
+
+```
+Stopped TOD-5.
+  Worktree  /repo/.worktrees/tod-5 — clean
+  Branch    tod-5 — 1 commit no remote has
+            publish with 'epic issue pr TOD-5'
+            free the disk with 'epic wt remove tod-5'
+```
+
+The unpushed commit is the line that matters. A worktree is gigabyte-scale (a small Next project
+carries ~1.6 GB of `node_modules`), but disk is recoverable; a commit only this machine has is
+not. A later **cloud** build of the same issue refuses to run rather than discard it — the
+control plane answers `REMOTE_WOULD_DISCARD_LOCAL_WORK` — so `epic issue pr <ID>` is the move
+while the context is fresh. Want the disk back? That means you are done with the issue:
+`epic wt remove <branch>`, or `epic issue close <ID>` to abandon it outright.
 
 ## Marketplace: an issue, a proposal, a paid contract
 
@@ -283,6 +403,13 @@ profile, usually via `epic --as <admin-profile>`.
 | "session in progress" but nothing is running | Sidecar outlived its tmux session | `epic issue stop <ID>` / `epic prd stop <ID>`, then re-run |
 | A PRD sits in `generating` / `breaking` forever | Its agent was killed, so the settle hook never ran | `epic prd stop <PRD-ID>` — it reverts the status to `draft` |
 | Nothing here stops a cloud build | `issue stop` / `prd stop` are local-session commands | Stop it from the web app |
+| Ctrl-C did not stop a prototype or screen build | Every prototype turn is durable and runs on Epic; Ctrl-C detaches | `epic prototype stop <ref>` |
+| A prototype sits in `building` with nothing running | The status outlived the run | `epic prototype stop <ref>` — it exits 0 and clears it |
+| `PROTOTYPE_BUSY` | A prototype runs one build at a time | Wait for it, or `epic prototype stop <ref>` |
+| `PROTOTYPE_HAS_NOTHING_TO_BUILD` | Every screen is completed and `--rebuild` was not passed | `epic prototype build <ref> --rebuild`, or one screen with `epic screen build <ref> <path> --rebuild` |
+| `PROTOTYPE_NEEDS_CREDENTIAL` | A prototype always builds on Epic, so the account token is required — a local `claude` login is a different thing | `epic credential login` |
+| `SCREEN_BLOCKED_BY_DEPENDENCY` | Its dependency has not completed | `epic prototype screens <ref>` to see which, then build that one — or the whole plan in order |
+| A planning turn settled with no screens | The agent never registered a plan; that is a failed turn | Re-run `epic prototype new <prd-ref>` — it reattaches to the same prototype |
 | `409 ISSUE_LOCKED_BUILDING` | A build owns the content | `epic issue sessions`; wait, or stop the build |
 | "not linked to a project" | No `projectId` in this repo | `epic project link <ref>` |
 | `epic project build` is not a command | Project-level building does not exist | `epic prd build <PRD-ID>`, or `epic issue build <ID>` |
@@ -296,6 +423,7 @@ profile, usually via `epic --as <admin-profile>`.
 | A detached (`-b`) agent vanished right after starting | Its tmux server was a child of the shell that launched it and died with it | Launch it detached from the process group: `setsid epic issue build <ID> -b` |
 | A remote build starts, then fails on its first call home | The sandbox cannot reach a `localhost` backend | Build locally, or point at a publicly reachable backend |
 | The agent ignored the plan/execute/verify workflow | The repo has no lifecycle skills for the prompt to name | `epic skill install --project` |
+| `.worktrees` is eating the disk | Only `merge` and `close` reclaim one; `stop` keeps it on purpose | `epic wt list`, then `epic wt remove <branch>` — publish first if `stop` reported unpushed commits |
 
 Content that was already PATCHed is safe in the database; a phase that dies mid-flight leaves
 its buffer on disk and settles on the next foreground run of that phase.

--- a/.agents/skills/epic/references/commands.md
+++ b/.agents/skills/epic/references/commands.md
@@ -10,7 +10,12 @@ Conventions used below:
 - `--provider claude|claude-headless|codex|opencode` — which agent runs the phase (the PRD
   authoring commands accept `claude|codex`). Defaults to the project's agent, read from the
   API. An unknown value, or the flag with no value, is an error naming the accepted set.
-- `--model NAME` — override the Claude model for every agent in the run.
+- `--model NAME` — override the Claude model for every agent in the run. Only the `issue`
+  commands that reach an agent take it (`build`, `plan`, `execute`, `verify`, `fix`, `review`,
+  `merge`, `approve`, `interview`, `attach`, `message`, `start`) plus `prototype new`.
+  **`prd build` and `prd break` do not accept it** — there is no per-PRD model override; to
+  build a PRD's issues on a specific model, build each `epic issue build <ID> --model NAME`
+  yourself instead of `epic prd build`.
 - `<ID>` — an issue identifier (`TOD-3`), its sequence number (`3`), or its raw id.
   `<PRD-ID>` — `PRD-1`, `1`, or the uuid.
 - Every subcommand below rejects flags it does not accept (exit 1, naming the accepted set),
@@ -36,14 +41,14 @@ Lifecycle only — nothing here runs an agent or builds. Building goes through
 | `epic issue show <ID> [-b]` | Metadata then the body. |
 | `epic issue build <ID> [--local\|--remote] [-b] [--foreground] [--no-tty] [--mode auto\|manual] [--base BRANCH] [--model NAME] [--provider P] [--record]` | plan → execute → verify → fix loop. **Local unless `--remote` (alias `--cloud`)** — no project setting decides this, and the resolution is offline. `--base` cuts the worktree from another branch. `--foreground` applies to remote builds (poll to completion). `--no-tty` exits the viewer when the build ends instead of waiting for `q`. A `-b` build that dies right after detaching is reported with its log, not as success. |
 | `epic issue plan\|execute\|verify\|fix\|review <ID> [-b] [--provider P] [--model NAME]` | Individual phases. `verify` also takes `-p PORT` (default 3000) and `--record` (one video per scenario; off by default because it slows the phase). |
-| `epic issue interview <ID> [--provider P]` | Q&A that rewrites the issue body. |
+| `epic issue interview <ID> [--provider P] [--model NAME]` | Q&A that rewrites the issue body. |
 | `epic issue pr <ID>` | Push the worktree branch and open (or surface) its PR. |
-| `epic issue merge <ID>` · `epic issue approve <ID>` | Agent-driven merge into main; `approve` also sets the issue Done. |
+| `epic issue merge <ID> [--provider P] [--model NAME]` · `epic issue approve <ID> [--provider P] [--model NAME]` | Agent-driven merge into main; `approve` also sets the issue Done. |
 | `epic issue close <ID>` · `epic issue assign <ID> <user>` | Status/assignee changes. |
 | `epic issue worktree <ID>` · `epic issue run <ID> -- <cmd>` | Create the worktree; run a command with its cwd set to that worktree (exit code propagates). |
-| `epic issue attach <ID>` · `epic issue message <ID> "<text>" [--session build\|verify\|merge] [-b]` | Attach to a live agent session; send it a message (resumes it). `attach` requires a TTY and refuses without one, before anything is spent. |
-| `epic issue log <ID> [--session build\|verify\|merge]` | Reads the transcript from disk, so it works after the session ends. Local builds only — remote transcripts live in the web app. |
-| `epic issue sessions` · `epic issue stop <ID>` | List tmux-backed sessions; end one and settle its sidecar (this is the fix for a stale "session in progress"). Local only — no CLI command stops a cloud build; use the web app. |
+| `epic issue attach <ID> [--session build\|verify\|merge] [--provider P] [--model NAME]` · `epic issue message <ID> "<text>" [--session build\|verify\|merge] [-b] [--provider P] [--model NAME]` | Attach to a live agent session; send it a message (resumes it). `attach` requires a TTY and refuses without one, before anything is spent. |
+| `epic issue log <ID> [--session build\|verify\|merge] [--provider P]` | Reads the transcript from disk, so it works after the session ends. Local builds only — a remote build's conversation is not retained anywhere (the web app keeps only phases/outcomes, plus the verify phase's own trace on the review page). |
+| `epic issue sessions` · `epic issue stop <ID>` | List tmux-backed sessions; end one and settle its sidecar (this is the fix for a stale "session in progress"). `stop` ends the run — tmux, the content lock, the agent's conversation — and requeues an in-flight issue to Queued; it never removes the worktree or branch, and reports what it left instead. Local only — no CLI command stops a cloud build; use the web app. |
 | `epic issue start <ID> [--foreground] [--model NAME]` | Alias of `build --remote`, retained for compatibility. Prefer `build --remote`. |
 
 ## prd
@@ -58,7 +63,7 @@ Lifecycle only — nothing here runs an agent or builds. Building goes through
 | `epic prd plan <PRD-ID> [-b] [--provider P]` | Rewrites the body as a structured spec. |
 | `epic prd interview <PRD-ID> [--provider P]` | Q&A that rewrites the body. |
 | `epic prd break <PRD-ID> [-b] [--replace] [--local] [--provider P]` | Decomposes into issues, created through the API in dependency order with their `dependsOn` edges. `--replace` deletes the previous breakdown's untouched issues first (addressed by row id) and is refused if any have started. On success the PRD settles on `ready`. `--local` = offline authoring. |
-| `epic prd build <PRD-ID> [--local\|--remote] [-b] [--mode auto\|manual] [--foreground] [--no-tty] [--record]` | Builds the PRD's issues in dependency order, stacking them onto the `prd-<n>` branch. Local unless `--remote` (alias `--cloud`). |
+| `epic prd build <PRD-ID> [--local\|--remote] [-b] [--mode auto\|manual] [--foreground] [--no-tty] [--record] [--parallel N] [--retry-failed]` | Builds the PRD's issues in dependency order, stacking them onto the `prd-<n>` branch. Local unless `--remote` (alias `--cloud`). `--parallel N` overrides `maxParallelIssues` from `.epic/settings.local.json` (default 4) for this run only; `0` is unlimited, spawning one worktree per ready issue. `--retry-failed` clears the sidecar of every issue this PRD left `failed` so they build again and their dependents stop being skipped; issues already done are untouched. |
 | `epic prd approve <PRD-ID>` | Lands the PRD: merges its `prd-<n> → main` PR, sets the status `done`, deletes the integration branch and points the sandbox at the new main. Valid only from `in_review`; idempotent once done. `--squash` is refused with the reason (the PRD PR lands as a merge commit). |
 | `epic prd attach <PRD-ID>` · `epic prd sessions` | Session control, same shape as the issue commands. `attach` lazily starts the PRD's agent — but only on a TTY, which it checks first. |
 | `epic prd stop <PRD-ID>` | Ends the session and settles the sidecar, **and** reverts a PRD stuck in `generating` / `breaking` back to `draft`. `building` is left alone (it belongs to the issue build queue). |
@@ -148,13 +153,37 @@ USD is the only currency the marketplace supports today.
 | `epic payouts status` · `epic payouts dashboard` | Account status; Stripe Express login link. |
 | `epic admin freelancer invite <email>` · `list [--status pending\|accepted\|revoked\|expired]` · `revoke <invitationId>` | Marketplace admin only — typically run as `epic --as <admin-profile> admin …`. |
 
-## stage and prototype
+## stage
 
 | Command | Notes |
 |---|---|
 | `epic stage assign --stage "<stage name>" --user <username>` | Auto-assign a user when an issue reaches that stage (e.g. `--stage "In Review"`). Stored in `.epic/settings.local.json` as `stageAssign`. |
-| `epic prototype new "<description>" [--web\|--terminal] [--provider P]` | Scaffolds a numbered prototype folder, writes `prompt.md`, and hands the terminal to the agent, which creates `page.tsx` (web) or `screen.tsx` (terminal). Root defaults to the project type. |
-| `epic prototype list` | Prototypes under `app/prototypes/` (web) or `prototypes/` (terminal); Enter resumes that prototype's agent session, `q` quits. |
+
+## prototype and screen
+
+A prototype is a **database-backed** record: a PRD turned into an ordered plan of screens,
+built and verified by agents in a sandbox Epic provisions. It scaffolds no folders — the
+folder-based prototype these commands used to create is gone. There is no `--local` and no
+local session: the account's agent credential is always required, Ctrl-C only detaches, and
+`epic prototype stop` is the only way to end a run from a shell.
+
+A screen has no minted id — `path` is unique within its prototype, so it is addressed as
+`<prototype-ref> <path>`. The raw uuid is accepted anywhere a screen is addressed.
+
+| Command | Notes |
+|---|---|
+| `epic prototype new <prd-ref> [--new] [--provider P] [--model <id>] [--effort <level>]` | One agent planning turn: creates the prototype and its ordered screen plan, follows the turn to settlement, prints the plan. Re-running reattaches (idempotency key = project + PRD); `--new` creates a second prototype from the same PRD on purpose. A settled turn that registered **zero screens is a failure**, not an empty plan. `--model` sets what the planning turn AND every later build run on (same setting `prototype model` changes afterwards) — without it nobody has chosen and each turn resolves the provider's default. `--effort` sets the reasoning level on models that take one. |
+| `epic prototype list [-b]` | Identifier (`PROTO-3`), title, status, source PRD, screen counts by status. Enter on a row shows its screens. **Prints nothing without `-b`** when there is no TTY. |
+| `epic prototype screens <prototype-ref>` | `PATH  POSITION  STATUS  NAME  LAST FAILURE`, ordered by position then creation time. Plain text always; takes no flags. A plan whose screens all failed is still a successful list (exit 0). |
+| `epic prototype build <prototype-ref> [--detached] [--rebuild] [--concurrency=N]` | Builds every screen not yet completed, in dependency order then by position. Attached by default — the CLI owns the queue and runs the same build `epic screen build` runs, **one screen at a time** from your terminal. `--detached` hands the plan to Epic Build, which builds **several screens at once**, as many as its machine can carry, and returns the run identifiers. `--concurrency=N` asks that build for at most N in flight (`--detached` only, refused otherwise); the machine still decides the ceiling, so asking for more than it holds changes nothing. `--rebuild` re-runs completed screens. A failed screen blocks only its dependents. **Exit non-zero only when a screen failed**; a blocked plan exits 0. |
+| `epic prototype model <prototype-ref> [<model-id>] [--effort L] [--default]` | Show or set the model the prototype's **build** runs on (not just the chat) — every screen agent reads it fresh each turn, so it also reaches screens already built on retry. Applies from the next turn; a turn already in flight keeps what it started on. Lives only in the Epic database. Refused while a build is in flight — `epic prototype stop <ref>` first. |
+| `epic prototype log <prototype-ref>` | The prototype's own planning conversation — the turn that turned the PRD into a screen plan. A screen's build is a different agent: use `epic screen log`. Read-only, works whether the turn is alive or finished. |
+| `epic screen build <prototype-ref> <path> [--detached] [--rebuild]` · `epic screen build <prototype-ref> --next [--detached] [--rebuild]` · `epic screen build <screen-id> …` | One screen, built and verified. Attached by default, exits on the terminal state. `--next` takes the screen the plan would build now (dependency order, then position) instead of naming one — the way to walk a plan one screen at a time. `--rebuild` is required to re-run a **completed** screen; failed or blocked retries without it. No `--local`. |
+| `epic screen log <prototype-ref> <path>` | What the agent that built this one screen actually did. Read-only, like `epic issue log`; a screen the build has not reached yet prints nothing and exits 0. |
+| `epic prototype stop <prototype-ref>` | Ends everything in flight — a full build with several screens running, or a single screen build (there is no `epic screen stop`). Writes a fact on the backend and returns; kills no local process. Idempotent: stopping a prototype with nothing running exits 0, and is how a stale `building` is cleared. Resume with `prototype build`, which skips completed screens. |
+
+Statuses — prototype: `draft` `planned` `building` `ready` `failed` `blocked` `archived`.
+Screen: `pending` `in_progress` `completed` `failed` `blocked`.
 
 ## Errors worth recognising
 
@@ -172,4 +201,10 @@ USD is the only currency the marketplace supports today.
 | `AGENT_CREDENTIAL_MISSING` / `AGENT_CREDENTIAL_REVOKED` | Same fix, found later: the build's own pre-flight. Confirm with `epic credential status`. |
 | `REMOTE_REQUIRES_GITHUB_APP` / `GITHUB_CONNECTION_REQUIRED` | Cloud builds push through the Epic GitHub App, so it must be installed on the repo's owner — the error carries the install URL. |
 | `DEFAULT_BRANCH_MUST_BE_MAIN` | Cloud-build precondition: the repo's default branch must be `main`. |
+| `PROTOTYPE_BUSY` | A prototype runs one build at a time and one is in flight. Wait, or `epic prototype stop <ref>`. |
+| `PROTOTYPE_HAS_NO_SCREENS` | Nothing to build — plan it first with `epic prototype new <prd-ref>`. |
+| `PROTOTYPE_HAS_NOTHING_TO_BUILD` | Every screen is completed. Pass `--rebuild`. |
+| `PROTOTYPE_NEEDS_CREDENTIAL` | A prototype always builds on Epic, so the account's agent credential is required even though nothing here is "remote". `epic credential login`. |
+| `SCREEN_ALREADY_COMPLETED` | Re-run it with `epic screen build <ref> <path> --rebuild`. |
+| `SCREEN_BLOCKED_BY_DEPENDENCY` | A dependency has not completed. `epic prototype screens <ref>` names it; or build the whole plan in order. |
 | `SNAPSHOT_OUTDATED` | The cloud sandbox ships an older `epic` than the backend requires. Not fixable from here — the snapshot has to be rebuilt. |


### PR DESCRIPTION
## Summary
- Fixed `--model` documentation gaps (interview, merge, approve, attach, message; prototype new/model/log; prd build --parallel/--retry-failed) mirroring real gaps in the CLI's own `--help`, fixed in epic-new/epic-cli#116.
- Fixed a stale claim that a remote build's transcript "lives in the web app" — it isn't retained anywhere except phases/outcomes and the verify phase's own trace.
- Content is now byte-identical to the reconciled canonical copy in epic-cli and every other repo carrying this skill.

## Test plan
- [x] Content verified byte-identical to the reconciled canonical copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)