### PR TITLE
docs(skill): tell fix not to fight over the dev server port

### DIFF
--- a/.agents/skills/fix/SKILL.md
+++ b/.agents/skills/fix/SKILL.md
@@ -7,6 +7,8 @@ description: Repair a web issue's implementation so its failing verify scenarios
 
 You are repairing a web issue's implementation so that its failing verify scenarios pass on the next verify run. Plan and execute have already run in this session, so you have the ephemeral issue buffer, the plan, and the implementation context loaded — focus only on the failures the user hands you.
 
+There is no separate fix server to boot: the preview you check your changes against is already running (supervisor-managed in the sandbox; `epic preview start` locally). If it doesn't respond, wait a moment and retry — **never start a second dev server, and never `pkill`/`kill` the dev or `next` process as troubleshooting.** It is the same server serving the page you are about to check; killing it destroys your own test target and its compiled routes, and starting a second one on the same port fails with `EADDRINUSE` and proves nothing.
+
 ## Workflow
 
 1. Re-read the issue buffer's `## Behavior: <name>` block to ground yourself in the rules and scenarios the failures are derived from.


### PR DESCRIPTION
## Summary
The `fix` skill has no idea a dev server is already running for the issue it's fixing — pm2-managed in a remote sandbox, or `epic preview start` locally. On a real build (TOD-1), the fix agent ran its own `bun run dev &` to test a change, hit `EADDRINUSE`, then `pkill`'d / `kill -9`'d the process trying to clear the port — killing the very preview it was about to check its own fix against.

`.agents/skills/verify/SKILL.md` already carries this exact warning ("never start a second dev server", "never `pkill` the dev/next servers as memory triage") — fix drives the same browser-testing step (its workflow step 3, "navigate to the page in the browser and walk the UI") but never got it. Ported the warning verbatim.

Mirrors epic-new/epic-cli#117.

## Test plan
- [x] Reproduced against a live build: pulled the fix agent's transcript from prod and confirmed the exact `EADDRINUSE` + `pkill -f "next dev"` / `kill -9` sequence
- [x] Confirmed the verify skill already has this guidance and fix doesn't

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the dev-server warning to the `fix` skill so the fix agent no longer starts a second dev server or kills the existing preview it checks against. The `verify` skill already had this guidance; `fix` runs the same browser-testing step and now matches it.

<sup>Written for commit 8074e311683c5ef76eb0f5c49c1bde3c79431062. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/epic-new/epic-web/pull/49?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

